### PR TITLE
Add unit tests for web module

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -27,4 +27,5 @@ dependencies {
     implementation("org.xerial:sqlite-jdbc:3.49.1.0")
 
     testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("io.mockk:mockk:1.13.12")
 }

--- a/web/src/test/kotlin/com/rsstowhisper/web/SearchResourceTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/SearchResourceTest.kt
@@ -1,0 +1,216 @@
+package com.rsstowhisper.web
+
+import com.rsstowhisper.web.db.EpisodeRepository
+import com.rsstowhisper.web.models.Episode
+import com.rsstowhisper.web.models.FilterOptions
+import com.rsstowhisper.web.models.SearchFilters
+import com.rsstowhisper.web.models.SearchResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import jakarta.ws.rs.core.Response
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.IContext
+
+class SearchResourceTest {
+    private val repository: EpisodeRepository = mockk()
+
+    // TemplateEngine is a concrete class; MockK can subclass it.
+    private val templateEngine: TemplateEngine = mockk()
+
+    // Construct the resource manually — all fields are lateinit var so we can
+    // set them directly without the CDI container.
+    private val resource =
+        SearchResource().also {
+            it.repository = repository
+            it.templateEngine = templateEngine
+            it.audioBaseUrl = "http://audio.example.com/" // trailing slash — to verify trimming
+        }
+
+    // --- index ---
+
+    @Test
+    fun `index redirects to search`() {
+        val response = resource.index()
+        assertEquals(Response.Status.SEE_OTHER.statusCode, response.status)
+        assertEquals("/search", response.location.toString())
+    }
+
+    // --- search ---
+
+    @Test
+    fun `search renders full template when no HTMX header`() {
+        stubSearchDependencies()
+        every { templateEngine.process("search", any<IContext>()) } returns "<html>full</html>"
+
+        val result =
+            resource.search("", emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), 1, null)
+
+        assertEquals("<html>full</html>", result)
+    }
+
+    @Test
+    fun `search renders partial fragment for HTMX requests`() {
+        stubSearchDependencies()
+        every { templateEngine.process("search", setOf("app"), any<IContext>()) } returns "<div>partial</div>"
+
+        val result =
+            resource.search("", emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), 1, "true")
+
+        assertEquals("<div>partial</div>", result)
+    }
+
+    @Test
+    fun `search trims whitespace from query before passing to repository`() {
+        val captured = slot<SearchFilters>()
+        every { repository.search(capture(captured)) } returns emptySearchResult()
+        every { repository.getFilterOptions(any()) } returns emptyFilterOptions()
+        every { templateEngine.process("search", any<IContext>()) } returns ""
+
+        resource.search("  kotlin  ", emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), 1, null)
+
+        assertEquals("kotlin", captured.captured.query)
+    }
+
+    @Test
+    fun `search coerces page below 1 up to 1`() {
+        val captured = slot<SearchFilters>()
+        every { repository.search(capture(captured)) } returns emptySearchResult()
+        every { repository.getFilterOptions(any()) } returns emptyFilterOptions()
+        every { templateEngine.process("search", any<IContext>()) } returns ""
+
+        resource.search("", emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), -5, null)
+
+        assertEquals(1, captured.captured.page)
+    }
+
+    // --- episode ---
+
+    @Test
+    fun `episode returns 404 when episode not found`() {
+        every { repository.getEpisodeById("missing") } returns null
+
+        val response = resource.episode("missing")
+
+        assertEquals(Response.Status.NOT_FOUND.statusCode, response.status)
+    }
+
+    @Test
+    fun `episode returns 200 with rendered HTML when found`() {
+        every { repository.getEpisodeById("ep1") } returns minimalEpisode()
+        every { templateEngine.process("episode", any<IContext>()) } returns "<html>episode</html>"
+
+        val response = resource.episode("ep1")
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+        assertEquals("<html>episode</html>", response.entity)
+    }
+
+    @Test
+    fun `episode linkifies plain-text summary`() {
+        every { repository.getEpisodeById("ep1") } returns minimalEpisode(summary = "Visit https://example.com for more")
+
+        val ctxSlot = slot<IContext>()
+        every { templateEngine.process("episode", capture(ctxSlot)) } returns ""
+
+        resource.episode("ep1")
+
+        val linkifiedSummary = ctxSlot.captured.getVariable("linkifiedSummary") as String
+        assertTrue(
+            linkifiedSummary.contains("""href="https://example.com""""),
+            "Expected linkified URL in: $linkifiedSummary",
+        )
+    }
+
+    @Test
+    fun `episode does not linkify summary that already contains HTML`() {
+        val htmlSummary = "<p>Already <b>formatted</b></p>"
+        every { repository.getEpisodeById("ep1") } returns minimalEpisode(summary = htmlSummary)
+
+        val ctxSlot = slot<IContext>()
+        every { templateEngine.process("episode", capture(ctxSlot)) } returns ""
+
+        resource.episode("ep1")
+
+        val linkifiedSummary = ctxSlot.captured.getVariable("linkifiedSummary") as String
+        assertEquals(htmlSummary, linkifiedSummary)
+    }
+
+    @Test
+    fun `episode trims trailing slash from audio base URL`() {
+        every { repository.getEpisodeById("ep1") } returns minimalEpisode()
+
+        val ctxSlot = slot<IContext>()
+        every { templateEngine.process("episode", capture(ctxSlot)) } returns ""
+
+        resource.episode("ep1")
+
+        val audioBaseUrl = ctxSlot.captured.getVariable("audioBaseUrl") as String
+        assertEquals("http://audio.example.com", audioBaseUrl)
+    }
+
+    @Test
+    fun `episode provides empty transcript lines when transcript is null`() {
+        every { repository.getEpisodeById("ep1") } returns minimalEpisode(transcript = null)
+
+        val ctxSlot = slot<IContext>()
+        every { templateEngine.process("episode", capture(ctxSlot)) } returns ""
+
+        resource.episode("ep1")
+
+        @Suppress("UNCHECKED_CAST")
+        val transcriptLines = ctxSlot.captured.getVariable("transcriptLines") as List<*>
+        assertTrue(transcriptLines.isEmpty())
+    }
+
+    @Test
+    fun `episode parses transcript lines when transcript is present`() {
+        every { repository.getEpisodeById("ep1") } returns minimalEpisode(transcript = "0\tHello\n1000\tWorld")
+
+        val ctxSlot = slot<IContext>()
+        every { templateEngine.process("episode", capture(ctxSlot)) } returns ""
+
+        resource.episode("ep1")
+
+        @Suppress("UNCHECKED_CAST")
+        val transcriptLines = ctxSlot.captured.getVariable("transcriptLines") as List<*>
+        assertEquals(2, transcriptLines.size)
+    }
+
+    // --- helpers ---
+
+    private fun stubSearchDependencies() {
+        every { repository.search(any()) } returns emptySearchResult()
+        every { repository.getFilterOptions(any()) } returns emptyFilterOptions()
+    }
+
+    private fun emptySearchResult() = SearchResult(emptyList(), 0, 1, 10)
+
+    private fun emptyFilterOptions() = FilterOptions(emptyList(), emptyList(), emptyList())
+
+    private fun minimalEpisode(
+        summary: String? = null,
+        transcript: String? = null,
+    ) = Episode(
+        id = "ep1",
+        podcastTitle = null,
+        podcastImage = null,
+        podcastCollections = null,
+        episodeTitle = null,
+        episodePublishedOn = null,
+        episodeAudioLink = null,
+        episodeWebLink = null,
+        episodeImage = null,
+        episodeSummary = summary,
+        episodeNumber = null,
+        episodeSeason = null,
+        episodeType = null,
+        episodeDuration = null,
+        episodeRelativeMp3Path = null,
+        allTags = null,
+        transcript = transcript,
+    )
+}

--- a/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
@@ -1,0 +1,304 @@
+package com.rsstowhisper.web.models
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SearchModelsTest {
+    @Nested
+    inner class FormatDuration {
+        @Test
+        fun `zero seconds`() = assertEquals("0m", formatDuration(0))
+
+        @Test
+        fun `less than one minute`() = assertEquals("0m", formatDuration(59))
+
+        @Test
+        fun `exactly one minute`() = assertEquals("1m", formatDuration(60))
+
+        @Test
+        fun `fifty-nine minutes`() = assertEquals("59m", formatDuration(3599))
+
+        @Test
+        fun `exactly one hour`() = assertEquals("1h 0m", formatDuration(3600))
+
+        @Test
+        fun `one hour and one minute`() = assertEquals("1h 1m", formatDuration(3661))
+
+        @Test
+        fun `two hours three minutes`() = assertEquals("2h 3m", formatDuration(7384))
+    }
+
+    @Nested
+    inner class FormatTimestamp {
+        @Test
+        fun `zero milliseconds`() = assertEquals("0:00", formatTimestamp(0))
+
+        @Test
+        fun `one second`() = assertEquals("0:01", formatTimestamp(1_000))
+
+        @Test
+        fun `one minute`() = assertEquals("1:00", formatTimestamp(60_000))
+
+        @Test
+        fun `one minute thirty seconds`() = assertEquals("1:30", formatTimestamp(90_000))
+
+        @Test
+        fun `fifty-nine minutes fifty-nine seconds`() = assertEquals("59:59", formatTimestamp(3_599_000))
+
+        @Test
+        fun `exactly one hour`() = assertEquals("1:00:00", formatTimestamp(3_600_000))
+
+        @Test
+        fun `one hour twenty-three minutes forty-five seconds`() = assertEquals("1:23:45", formatTimestamp(5_025_000))
+    }
+
+    @Nested
+    inner class ParseTranscript {
+        @Test
+        fun `empty string returns empty list`() = assertTrue(parseTranscript("").isEmpty())
+
+        @Test
+        fun `single valid line`() {
+            val lines = parseTranscript("1000\tHello world")
+            assertEquals(1, lines.size)
+            assertEquals(TranscriptLine(1000L, "Hello world"), lines[0])
+        }
+
+        @Test
+        fun `multiple valid lines`() {
+            val input = "0\tFirst\n1000\tSecond\n2000\tThird"
+            val lines = parseTranscript(input)
+            assertEquals(3, lines.size)
+            assertEquals("First", lines[0].text)
+            assertEquals("Second", lines[1].text)
+            assertEquals("Third", lines[2].text)
+        }
+
+        @Test
+        fun `lines without tab separator are skipped`() = assertTrue(parseTranscript("no tab here").isEmpty())
+
+        @Test
+        fun `lines with blank text are skipped`() = assertTrue(parseTranscript("1000\t   ").isEmpty())
+
+        @Test
+        fun `lines with non-numeric timestamp are skipped`() = assertTrue(parseTranscript("abc\tSome text").isEmpty())
+
+        @Test
+        fun `trims whitespace from text`() {
+            val lines = parseTranscript("1000\t  Hello  ")
+            assertEquals("Hello", lines[0].text)
+        }
+    }
+
+    @Nested
+    inner class Linkify {
+        @Test
+        fun `plain text is HTML escaped`() = assertEquals("Hello &amp; World", linkify("Hello & World"))
+
+        @Test
+        fun `angle brackets are escaped`() = assertEquals("a &lt;b&gt; c", linkify("a <b> c"))
+
+        @Test
+        fun `text with no URLs is returned escaped`() = assertEquals("No links here", linkify("No links here"))
+
+        @Test
+        fun `URL is wrapped in anchor tag`() {
+            val result = linkify("Visit https://example.com today")
+            assertEquals(
+                """Visit <a href="https://example.com" target="_blank">https://example.com</a> today""",
+                result,
+            )
+        }
+
+        @Test
+        fun `multiple URLs are all linkified`() {
+            val result = linkify("https://a.com and https://b.com")
+            assertTrue(result.contains("""href="https://a.com""""))
+            assertTrue(result.contains("""href="https://b.com""""))
+        }
+
+        @Test
+        fun `surrounding text with special chars is escaped`() {
+            val result = linkify("Tom & Jerry at https://example.com")
+            assertTrue(result.startsWith("Tom &amp; Jerry at "))
+        }
+    }
+
+    @Nested
+    inner class HasActiveFilters {
+        @Test
+        fun `empty filters returns false`() = assertFalse(SearchFilters().hasActiveFilters())
+
+        @Test
+        fun `blank query returns false`() = assertFalse(SearchFilters(query = "   ").hasActiveFilters())
+
+        @Test
+        fun `non-blank query returns true`() = assertTrue(SearchFilters(query = "test").hasActiveFilters())
+
+        @Test
+        fun `non-empty durations returns true`() = assertTrue(SearchFilters(durations = setOf("SHORT")).hasActiveFilters())
+
+        @Test
+        fun `non-empty podcasts returns true`() = assertTrue(SearchFilters(podcasts = setOf("My Podcast")).hasActiveFilters())
+
+        @Test
+        fun `non-empty collections returns true`() = assertTrue(SearchFilters(collections = setOf("Tech")).hasActiveFilters())
+
+        @Test
+        fun `non-empty tags returns true`() = assertTrue(SearchFilters(tags = setOf("kotlin")).hasActiveFilters())
+
+        @Test
+        fun `non-empty episodeTypes returns true`() = assertTrue(SearchFilters(episodeTypes = setOf("full")).hasActiveFilters())
+    }
+
+    @Nested
+    inner class BuildSearchUrl {
+        @Test
+        fun `empty filters produces base URL with no params`() = assertEquals("/search?", buildSearchUrl(SearchFilters()))
+
+        @Test
+        fun `query is included`() = assertTrue(buildSearchUrl(SearchFilters(query = "kotlin")).contains("q=kotlin"))
+
+        @Test
+        fun `page 1 is omitted`() = assertFalse(buildSearchUrl(SearchFilters(query = "test", page = 1)).contains("page="))
+
+        @Test
+        fun `page greater than 1 is included`() = assertTrue(buildSearchUrl(SearchFilters(page = 3)).contains("page=3"))
+
+        @Test
+        fun `multiple podcasts are all included`() {
+            val url = buildSearchUrl(SearchFilters(podcasts = setOf("PodA", "PodB")))
+            assertTrue(url.contains("podcast=PodA"))
+            assertTrue(url.contains("podcast=PodB"))
+        }
+
+        @Test
+        fun `multiple filter types are combined`() {
+            val url = buildSearchUrl(SearchFilters(query = "ai", durations = setOf("SHORT"), page = 2))
+            assertTrue(url.contains("q=ai"))
+            assertTrue(url.contains("duration=SHORT"))
+            assertTrue(url.contains("page=2"))
+        }
+    }
+
+    @Nested
+    inner class SearchResultPagination {
+        @Test
+        fun `zero results gives one total page`() {
+            val result = SearchResult(emptyList(), totalCount = 0, page = 1, pageSize = 10)
+            assertEquals(1, result.totalPages)
+            assertFalse(result.hasPrevious)
+            assertFalse(result.hasNext)
+        }
+
+        @Test
+        fun `results fitting exactly one page`() {
+            val result = SearchResult(emptyList(), totalCount = 10, page = 1, pageSize = 10)
+            assertEquals(1, result.totalPages)
+            assertFalse(result.hasPrevious)
+            assertFalse(result.hasNext)
+        }
+
+        @Test
+        fun `results spanning two pages - first page`() {
+            val result = SearchResult(emptyList(), totalCount = 11, page = 1, pageSize = 10)
+            assertEquals(2, result.totalPages)
+            assertFalse(result.hasPrevious)
+            assertTrue(result.hasNext)
+        }
+
+        @Test
+        fun `results spanning two pages - second page`() {
+            val result = SearchResult(emptyList(), totalCount = 11, page = 2, pageSize = 10)
+            assertEquals(2, result.totalPages)
+            assertTrue(result.hasPrevious)
+            assertFalse(result.hasNext)
+        }
+
+        @Test
+        fun `partial last page is counted as a full page`() {
+            val result = SearchResult(emptyList(), totalCount = 21, page = 1, pageSize = 10)
+            assertEquals(3, result.totalPages)
+        }
+    }
+
+    @Nested
+    inner class EpisodeComputedProperties {
+        private fun episode(
+            duration: Int? = null,
+            snippet: String? = null,
+            mp3Path: String? = null,
+            tags: String? = null,
+        ) = Episode(
+            id = "1",
+            podcastTitle = null,
+            podcastImage = null,
+            podcastCollections = null,
+            episodeTitle = null,
+            episodePublishedOn = null,
+            episodeAudioLink = null,
+            episodeWebLink = null,
+            episodeImage = null,
+            episodeSummary = null,
+            episodeNumber = null,
+            episodeSeason = null,
+            episodeType = null,
+            episodeDuration = duration,
+            episodeRelativeMp3Path = mp3Path,
+            allTags = tags,
+            snippet = snippet,
+        )
+
+        @Test
+        fun `formattedDuration is null when episodeDuration is null`() = assertNull(episode().formattedDuration)
+
+        @Test
+        fun `formattedDuration formats duration correctly`() = assertEquals("1h 0m", episode(duration = 3600).formattedDuration)
+
+        @Test
+        fun `tagList is empty when allTags is null`() = assertTrue(episode().tagList.isEmpty())
+
+        @Test
+        fun `tagList splits on comma`() = assertEquals(listOf("a", "b"), episode(tags = "a,b").tagList)
+
+        @Test
+        fun `tagList trims whitespace from each tag`() = assertEquals(listOf("a", "b"), episode(tags = " a , b ").tagList)
+
+        @Test
+        fun `tagList filters out blank entries`() = assertTrue(episode(tags = ",").tagList.isEmpty())
+
+        @Test
+        fun `wavPath is null when episodeRelativeMp3Path is null`() = assertNull(episode().wavPath)
+
+        @Test
+        fun `wavPath replaces mp3 extension with wav`() = assertEquals("audio/ep.wav", episode(mp3Path = "audio/ep.mp3").wavPath)
+
+        @Test
+        fun `strippedSnippet removes timestamp prefixes and collapses double spaces`() {
+            // TIMESTAMP_REGEX matches 4+ digits followed by a tab
+            val ep = episode(snippet = "12345\tHello 67890\tworld")
+            assertEquals(" Hello world", ep.strippedSnippet)
+        }
+
+        @Test
+        fun `strippedSnippet is null when snippet is null`() = assertNull(episode().strippedSnippet)
+    }
+
+    @Nested
+    inner class TranscriptLineProperties {
+        @Test
+        fun `seconds converts milliseconds correctly`() {
+            assertEquals(1.5, TranscriptLine(1500L, "text").seconds, 0.001)
+        }
+
+        @Test
+        fun `display formats timestamp without hours`() = assertEquals("1:00", TranscriptLine(60_000L, "").display)
+
+        @Test
+        fun `display formats timestamp with hours`() = assertEquals("1:00:00", TranscriptLine(3_600_000L, "").display)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 71 unit tests across two test classes: `SearchModelsTest` and `SearchResourceTest`
- `SearchModelsTest` covers all utility functions in `SearchModels.kt` — `formatDuration`, `formatTimestamp`, `parseTranscript`, `linkify`, `hasActiveFilters`, `buildSearchUrl`, pagination properties, and computed properties on `Episode`/`TranscriptLine`
- `SearchResourceTest` tests the REST layer with MockK mocks for `EpisodeRepository` and `TemplateEngine`, covering HTMX partial/full rendering, 404 handling, `linkify` decision logic, audio URL trimming, query trimming, and page clamping
- Adds `io.mockk:mockk:1.13.12` as a test dependency

`EpisodeRepository` is not covered — its logic is dynamic SQL building, where mocking JDBC would be fragile. Integration tests with an in-memory SQLite database would be more appropriate if that coverage is wanted later.

## Test plan

- [x] `./gradlew :web:test` — all 71 tests pass
- [x] `./gradlew ktlintFormat` — no lint violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)