### PR TITLE
Make pipeline .env loading robust to working directory

### DIFF
--- a/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
@@ -27,24 +27,29 @@ data class AppConfig(
 
             val dataDirectory =
                 env["PIPELINE_DATA_DIRECTORY"]
-                    ?: error("PIPELINE_DATA_DIRECTORY must be set in .env")
+                    ?: error("PIPELINE_DATA_DIRECTORY must be set in .env or the environment")
             val whisperModel =
                 env["PIPELINE_WHISPER_MODEL_PATH"]
-                    ?: error("PIPELINE_WHISPER_MODEL_PATH must be set in .env")
+                    ?: error("PIPELINE_WHISPER_MODEL_PATH must be set in .env or the environment")
 
             return raw.copy(dataDirectory = dataDirectory, whisperModel = whisperModel)
         }
 
         internal fun loadDotEnv(): Map<String, String> {
             val file = File(".env")
-            if (!file.exists()) return emptyMap()
-            return file
-                .readLines()
-                .filter { it.isNotBlank() && !it.startsWith("#") }
-                .mapNotNull { line ->
-                    val eq = line.indexOf('=')
-                    if (eq < 0) null else line.substring(0, eq).trim() to line.substring(eq + 1).trim()
-                }.toMap()
+            val fileVars =
+                if (!file.exists()) {
+                    emptyMap()
+                } else {
+                    file
+                        .readLines()
+                        .filter { it.isNotBlank() && !it.startsWith("#") }
+                        .mapNotNull { line ->
+                            val eq = line.indexOf('=')
+                            if (eq < 0) null else line.substring(0, eq).trim() to line.substring(eq + 1).trim()
+                        }.toMap()
+                }
+            return fileVars + System.getenv()
         }
     }
 }

--- a/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
@@ -36,19 +36,17 @@ data class AppConfig(
         }
 
         internal fun loadDotEnv(): Map<String, String> {
-            val file = File(".env")
+            val candidates = listOf(File(".env"), File("pipeline/.env"))
+            val file = candidates.firstOrNull { it.exists() }
             val fileVars =
-                if (!file.exists()) {
-                    emptyMap()
-                } else {
-                    file
-                        .readLines()
-                        .filter { it.isNotBlank() && !it.startsWith("#") }
-                        .mapNotNull { line ->
-                            val eq = line.indexOf('=')
-                            if (eq < 0) null else line.substring(0, eq).trim() to line.substring(eq + 1).trim()
-                        }.toMap()
-                }
+                file
+                    ?.readLines()
+                    ?.filter { it.isNotBlank() && !it.startsWith("#") }
+                    ?.mapNotNull { line ->
+                        val eq = line.indexOf('=')
+                        if (eq < 0) null else line.substring(0, eq).trim() to line.substring(eq + 1).trim()
+                    }?.toMap()
+                    ?: emptyMap()
             return fileVars + System.getenv()
         }
     }


### PR DESCRIPTION
## Summary

- Merges `System.getenv()` into the env map so variables can be set as real shell exports (useful for cron jobs and systemd services)
- Falls back to `pipeline/.env` if `.env` is not found in the current working directory, so the binary works when run from the project root

## Test plan

- [ ] Run from project root — picks up `pipeline/.env`
- [ ] Run from `pipeline/` directory — picks up `.env` directly
- [ ] Variables exported in shell take priority over `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)