### PR TITLE
Consolidate pipeline config into AppConfig and expand test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,18 @@ Three-stage pipeline for podcast transcription and full-text search:
 ### Pipeline (transcription)
 
 ```bash
-./gradlew :pipeline:run --args="-c pods.yaml"
+./gradlew :pipeline:run
 ```
 
+All configuration comes from `pipeline/.env` — copy `pipeline/.env.example` and fill in:
+- `PIPELINE_CONFIG_PATH` — path to your `pods.yaml`
+- `PIPELINE_DATA_DIRECTORY` — where audio and transcripts are stored
+- `PIPELINE_WHISPER_SERVER_URL` — URL of the whisper HTTP server
+- `PIPELINE_VERBOSE` — set to `true` to enable debug logging
+
 Configure `pods.yaml` with:
-- `data_directory` — where audio and transcripts are stored
-- `whisper_model` — path to a GGML model file (e.g. `ggml-large-v3-turbo.bin`)
 - `podcasts` — list of RSS feeds with `name`, `url`, and `collections` tags
+- `skip_after_consecutive` — stop processing a feed after N already-transcribed episodes in a row (default: 20)
 
 External tools required on `PATH`: `ffmpeg`, `whisper-cli`
 
@@ -63,5 +68,11 @@ APP_AUDIO_BASE_URL=http://your-audio-server:port
 ## Code style
 
 - Kotlin throughout (JVM 21), ktlint enforced — run `./gradlew ktlintFormat` before committing
+- Always run `./gradlew ktlintFormat && ./gradlew test` before committing
 - `pipeline` JVM heap is set to 4GB by default (`-Xmx4g`) to handle large whisper model loads
 - Thymeleaf is used as a plain library in `web` (no Quarkiverse extension) via a hand-rolled CDI producer
+
+## Git workflow
+
+- Always create a feature branch from `main` before making changes — never commit directly to `main`
+- Branch naming convention: `baz8080/<short-description>`

--- a/pipeline/.env.example
+++ b/pipeline/.env.example
@@ -1,3 +1,4 @@
 PIPELINE_DATA_DIRECTORY=/path/to/download-directory
 PIPELINE_WHISPER_SERVER_URL=http://localhost:8080
 PIPELINE_CONFIG_PATH=/path/to/pods.yaml
+PIPELINE_VERBOSE=false

--- a/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
@@ -1,8 +1,8 @@
 package com.rsstowhisper
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -13,39 +13,47 @@ data class AppConfig(
     val verbose: Boolean = false,
     val dataDirectory: String = "",
     val whisperServerUrl: String = "",
-    @param:JsonProperty("skip_after_consecutive") val skipAfterConsecutive: Int = 20,
+    val skipAfterConsecutive: Int = 20,
     val podcasts: List<PodcastConfig> = emptyList(),
 ) {
     companion object {
         private val mapper =
             ObjectMapper(YAMLFactory())
                 .registerModule(KotlinModule.Builder().build())
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
 
-        fun load(path: String): AppConfig {
-            val env = loadDotEnv()
-            val raw: AppConfig = mapper.readValue(File(path))
+        fun load(): AppConfig = load(loadDotEnv())
 
+        internal fun load(env: Map<String, String>): AppConfig {
+            val configPath =
+                env["PIPELINE_CONFIG_PATH"]
+                    ?: error("PIPELINE_CONFIG_PATH must be set in .env")
             val dataDirectory =
                 env["PIPELINE_DATA_DIRECTORY"]
                     ?: error("PIPELINE_DATA_DIRECTORY must be set in .env")
             val whisperServerUrl =
                 env["PIPELINE_WHISPER_SERVER_URL"]
                     ?: error("PIPELINE_WHISPER_SERVER_URL must be set in .env")
+            val verbose = env["PIPELINE_VERBOSE"]?.toBoolean() ?: false
 
-            return raw.copy(dataDirectory = dataDirectory, whisperServerUrl = whisperServerUrl)
+            val raw: AppConfig = mapper.readValue(File(configPath))
+            return raw.copy(dataDirectory = dataDirectory, whisperServerUrl = whisperServerUrl, verbose = verbose)
         }
 
         internal fun loadDotEnv(): Map<String, String> {
-            val file = File(".env")
+            val file = File("pipeline/.env")
             if (!file.exists()) return emptyMap()
-            return file
-                .readLines()
+            return loadDotEnv(file.readText())
+        }
+
+        internal fun loadDotEnv(content: String): Map<String, String> =
+            content
+                .lines()
                 .filter { it.isNotBlank() && !it.startsWith("#") }
                 .mapNotNull { line ->
                     val eq = line.indexOf('=')
                     if (eq < 0) null else line.substring(0, eq).trim() to line.substring(eq + 1).trim()
                 }.toMap()
-        }
     }
 }
 

--- a/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
@@ -5,24 +5,12 @@ import ch.qos.logback.classic.LoggerContext
 import com.rsstowhisper.pipeline.PodcastPipeline
 import org.slf4j.LoggerFactory
 
-fun main(args: Array<String>) {
-    val env = AppConfig.loadDotEnv()
-    val configFile =
-        args.find { it == "-c" || it == "--config" }
-            ?.let { args[args.indexOf(it) + 1] }
-            ?: env["PIPELINE_CONFIG_PATH"]
-            ?: run {
-                println("No config file specified. Use --config or set PIPELINE_CONFIG_PATH in .env")
-                return
-            }
-
-    println("Using $configFile config")
-
+fun main() {
     val config: AppConfig =
         try {
-            AppConfig.load(configFile)
+            AppConfig.load()
         } catch (e: Exception) {
-            println("Cannot read configuration file: ${e.message}")
+            println("Cannot load configuration: ${e.message}")
             return
         }
 

--- a/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
@@ -9,14 +9,16 @@ import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
-open class Transcriber(private val serverUrl: String) {
-    private val logger = LoggerFactory.getLogger(Transcriber::class.java)
-    private val httpClient =
+open class Transcriber(
+    private val serverUrl: String,
+    private val httpClient: OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(90, TimeUnit.MINUTES)
             .writeTimeout(30, TimeUnit.MINUTES)
-            .build()
+            .build(),
+) {
+    private val logger = LoggerFactory.getLogger(Transcriber::class.java)
 
     open fun transcribe(wavPath: Path): String {
         val requestBody =

--- a/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
@@ -1,0 +1,135 @@
+package com.rsstowhisper
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AppConfigTest {
+    @Test
+    fun `loadDotEnv parses key=value pairs`() {
+        val result = AppConfig.loadDotEnv(
+            """
+            FOO=bar
+            BAZ=qux
+            """.trimIndent()
+        )
+        assertEquals(mapOf("FOO" to "bar", "BAZ" to "qux"), result)
+    }
+
+    @Test
+    fun `loadDotEnv ignores blank lines and comments`() {
+        val result = AppConfig.loadDotEnv(
+            """
+            # a comment
+            FOO=bar
+
+            # another comment
+            BAZ=qux
+            """.trimIndent()
+        )
+        assertEquals(mapOf("FOO" to "bar", "BAZ" to "qux"), result)
+    }
+
+    @Test
+    fun `loadDotEnv handles empty input`() {
+        assertEquals(emptyMap(), AppConfig.loadDotEnv(""))
+    }
+
+    @Test
+    fun `load overrides dataDirectory and whisperServerUrl from env`(@TempDir tmp: Path) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("data_directory: from-yaml\nwhisper_server_url: from-yaml\nverbose: false\n")
+
+        val config = AppConfig.load(
+            mapOf(
+                "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                "PIPELINE_DATA_DIRECTORY" to "/env/data",
+                "PIPELINE_WHISPER_SERVER_URL" to "http://env-whisper",
+            )
+        )
+
+        assertEquals("/env/data", config.dataDirectory)
+        assertEquals("http://env-whisper", config.whisperServerUrl)
+    }
+
+    @Test
+    fun `load sets verbose from env`(@TempDir tmp: Path) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("verbose: false\n")
+
+        val config = AppConfig.load(
+            mapOf(
+                "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                "PIPELINE_DATA_DIRECTORY" to "/data",
+                "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                "PIPELINE_VERBOSE" to "true",
+            )
+        )
+
+        assertEquals(true, config.verbose)
+    }
+
+    @Test
+    fun `load defaults verbose to false when absent`(@TempDir tmp: Path) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("podcasts: []\n")
+
+        val config = AppConfig.load(
+            mapOf(
+                "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                "PIPELINE_DATA_DIRECTORY" to "/data",
+                "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+            )
+        )
+
+        assertEquals(false, config.verbose)
+    }
+
+    @Test
+    fun `load errors when PIPELINE_CONFIG_PATH is missing`() {
+        val ex = assertFailsWith<IllegalStateException> {
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                )
+            )
+        }
+        assertEquals("PIPELINE_CONFIG_PATH must be set in .env", ex.message)
+    }
+
+    @Test
+    fun `load errors when PIPELINE_DATA_DIRECTORY is missing`(@TempDir tmp: Path) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("podcasts: []\n")
+
+        val ex = assertFailsWith<IllegalStateException> {
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                )
+            )
+        }
+        assertEquals("PIPELINE_DATA_DIRECTORY must be set in .env", ex.message)
+    }
+
+    @Test
+    fun `load errors when PIPELINE_WHISPER_SERVER_URL is missing`(@TempDir tmp: Path) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("podcasts: []\n")
+
+        val ex = assertFailsWith<IllegalStateException> {
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                )
+            )
+        }
+        assertEquals("PIPELINE_WHISPER_SERVER_URL must be set in .env", ex.message)
+    }
+}

--- a/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
@@ -1,7 +1,6 @@
 package com.rsstowhisper
 
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,26 +9,28 @@ import kotlin.test.assertFailsWith
 class AppConfigTest {
     @Test
     fun `loadDotEnv parses key=value pairs`() {
-        val result = AppConfig.loadDotEnv(
-            """
-            FOO=bar
-            BAZ=qux
-            """.trimIndent()
-        )
+        val result =
+            AppConfig.loadDotEnv(
+                """
+                FOO=bar
+                BAZ=qux
+                """.trimIndent(),
+            )
         assertEquals(mapOf("FOO" to "bar", "BAZ" to "qux"), result)
     }
 
     @Test
     fun `loadDotEnv ignores blank lines and comments`() {
-        val result = AppConfig.loadDotEnv(
-            """
-            # a comment
-            FOO=bar
+        val result =
+            AppConfig.loadDotEnv(
+                """
+                # a comment
+                FOO=bar
 
-            # another comment
-            BAZ=qux
-            """.trimIndent()
-        )
+                # another comment
+                BAZ=qux
+                """.trimIndent(),
+            )
         assertEquals(mapOf("FOO" to "bar", "BAZ" to "qux"), result)
     }
 
@@ -39,97 +40,113 @@ class AppConfigTest {
     }
 
     @Test
-    fun `load overrides dataDirectory and whisperServerUrl from env`(@TempDir tmp: Path) {
+    fun `load overrides dataDirectory and whisperServerUrl from env`(
+        @TempDir tmp: Path,
+    ) {
         val yaml = tmp.resolve("pods.yaml").toFile()
         yaml.writeText("data_directory: from-yaml\nwhisper_server_url: from-yaml\nverbose: false\n")
 
-        val config = AppConfig.load(
-            mapOf(
-                "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
-                "PIPELINE_DATA_DIRECTORY" to "/env/data",
-                "PIPELINE_WHISPER_SERVER_URL" to "http://env-whisper",
+        val config =
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/env/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://env-whisper",
+                ),
             )
-        )
 
         assertEquals("/env/data", config.dataDirectory)
         assertEquals("http://env-whisper", config.whisperServerUrl)
     }
 
     @Test
-    fun `load sets verbose from env`(@TempDir tmp: Path) {
+    fun `load sets verbose from env`(
+        @TempDir tmp: Path,
+    ) {
         val yaml = tmp.resolve("pods.yaml").toFile()
         yaml.writeText("verbose: false\n")
 
-        val config = AppConfig.load(
-            mapOf(
-                "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
-                "PIPELINE_DATA_DIRECTORY" to "/data",
-                "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
-                "PIPELINE_VERBOSE" to "true",
+        val config =
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                    "PIPELINE_VERBOSE" to "true",
+                ),
             )
-        )
 
         assertEquals(true, config.verbose)
     }
 
     @Test
-    fun `load defaults verbose to false when absent`(@TempDir tmp: Path) {
+    fun `load defaults verbose to false when absent`(
+        @TempDir tmp: Path,
+    ) {
         val yaml = tmp.resolve("pods.yaml").toFile()
         yaml.writeText("podcasts: []\n")
 
-        val config = AppConfig.load(
-            mapOf(
-                "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
-                "PIPELINE_DATA_DIRECTORY" to "/data",
-                "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+        val config =
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                ),
             )
-        )
 
         assertEquals(false, config.verbose)
     }
 
     @Test
     fun `load errors when PIPELINE_CONFIG_PATH is missing`() {
-        val ex = assertFailsWith<IllegalStateException> {
-            AppConfig.load(
-                mapOf(
-                    "PIPELINE_DATA_DIRECTORY" to "/data",
-                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+        val ex =
+            assertFailsWith<IllegalStateException> {
+                AppConfig.load(
+                    mapOf(
+                        "PIPELINE_DATA_DIRECTORY" to "/data",
+                        "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                    ),
                 )
-            )
-        }
+            }
         assertEquals("PIPELINE_CONFIG_PATH must be set in .env", ex.message)
     }
 
     @Test
-    fun `load errors when PIPELINE_DATA_DIRECTORY is missing`(@TempDir tmp: Path) {
+    fun `load errors when PIPELINE_DATA_DIRECTORY is missing`(
+        @TempDir tmp: Path,
+    ) {
         val yaml = tmp.resolve("pods.yaml").toFile()
         yaml.writeText("podcasts: []\n")
 
-        val ex = assertFailsWith<IllegalStateException> {
-            AppConfig.load(
-                mapOf(
-                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
-                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+        val ex =
+            assertFailsWith<IllegalStateException> {
+                AppConfig.load(
+                    mapOf(
+                        "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                        "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                    ),
                 )
-            )
-        }
+            }
         assertEquals("PIPELINE_DATA_DIRECTORY must be set in .env", ex.message)
     }
 
     @Test
-    fun `load errors when PIPELINE_WHISPER_SERVER_URL is missing`(@TempDir tmp: Path) {
+    fun `load errors when PIPELINE_WHISPER_SERVER_URL is missing`(
+        @TempDir tmp: Path,
+    ) {
         val yaml = tmp.resolve("pods.yaml").toFile()
         yaml.writeText("podcasts: []\n")
 
-        val ex = assertFailsWith<IllegalStateException> {
-            AppConfig.load(
-                mapOf(
-                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
-                    "PIPELINE_DATA_DIRECTORY" to "/data",
+        val ex =
+            assertFailsWith<IllegalStateException> {
+                AppConfig.load(
+                    mapOf(
+                        "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                        "PIPELINE_DATA_DIRECTORY" to "/data",
+                    ),
                 )
-            )
-        }
+            }
         assertEquals("PIPELINE_WHISPER_SERVER_URL must be set in .env", ex.message)
     }
 }

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
@@ -31,11 +31,12 @@ class TranscriberTest {
             }
             .build()
 
-    private fun wavFile(tmp: Path): Path =
-        tmp.resolve("audio.wav").also { Files.writeString(it, "fake-wav-data") }
+    private fun wavFile(tmp: Path): Path = tmp.resolve("audio.wav").also { Files.writeString(it, "fake-wav-data") }
 
     @Test
-    fun `transcribe posts to the inference endpoint`(@TempDir tmp: Path) {
+    fun `transcribe posts to the inference endpoint`(
+        @TempDir tmp: Path,
+    ) {
         val requests = mutableListOf<okhttp3.Request>()
         Transcriber("http://whisper-server", clientReturning("WEBVTT\n", captureRequests = requests))
             .transcribe(wavFile(tmp))
@@ -46,7 +47,9 @@ class TranscriberTest {
     }
 
     @Test
-    fun `transcribe sends file as multipart with correct fields`(@TempDir tmp: Path) {
+    fun `transcribe sends file as multipart with correct fields`(
+        @TempDir tmp: Path,
+    ) {
         val requests = mutableListOf<okhttp3.Request>()
         Transcriber("http://whisper-server", clientReturning("WEBVTT\n", captureRequests = requests))
             .transcribe(wavFile(tmp))
@@ -59,23 +62,30 @@ class TranscriberTest {
     }
 
     @Test
-    fun `transcribe returns response body on success`(@TempDir tmp: Path) {
+    fun `transcribe returns response body on success`(
+        @TempDir tmp: Path,
+    ) {
         val vtt = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello world\n"
         val result = Transcriber("http://whisper-server", clientReturning(vtt)).transcribe(wavFile(tmp))
         assertEquals(vtt, result)
     }
 
     @Test
-    fun `transcribe throws on non-200 response`(@TempDir tmp: Path) {
-        val ex = assertFailsWith<RuntimeException> {
-            Transcriber("http://whisper-server", clientReturning(responseCode = 500))
-                .transcribe(wavFile(tmp))
-        }
+    fun `transcribe throws on non-200 response`(
+        @TempDir tmp: Path,
+    ) {
+        val ex =
+            assertFailsWith<RuntimeException> {
+                Transcriber("http://whisper-server", clientReturning(responseCode = 500))
+                    .transcribe(wavFile(tmp))
+            }
         assertTrue(ex.message!!.contains("500"))
     }
 
     @Test
-    fun `transcribe throws on empty body`(@TempDir tmp: Path) {
+    fun `transcribe throws on empty body`(
+        @TempDir tmp: Path,
+    ) {
         val client =
             OkHttpClient.Builder()
                 .addInterceptor { chain ->

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
@@ -1,0 +1,95 @@
+package com.rsstowhisper.external
+
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TranscriberTest {
+    private fun clientReturning(
+        body: String = "",
+        responseCode: Int = 200,
+        captureRequests: MutableList<okhttp3.Request>? = null,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                captureRequests?.add(chain.request())
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(responseCode)
+                    .message(if (responseCode == 200) "OK" else "Error")
+                    .body(body.toResponseBody())
+                    .build()
+            }
+            .build()
+
+    private fun wavFile(tmp: Path): Path =
+        tmp.resolve("audio.wav").also { Files.writeString(it, "fake-wav-data") }
+
+    @Test
+    fun `transcribe posts to the inference endpoint`(@TempDir tmp: Path) {
+        val requests = mutableListOf<okhttp3.Request>()
+        Transcriber("http://whisper-server", clientReturning("WEBVTT\n", captureRequests = requests))
+            .transcribe(wavFile(tmp))
+
+        val request = requests.single()
+        assertEquals("POST", request.method)
+        assertEquals("http://whisper-server/inference", request.url.toString())
+    }
+
+    @Test
+    fun `transcribe sends file as multipart with correct fields`(@TempDir tmp: Path) {
+        val requests = mutableListOf<okhttp3.Request>()
+        Transcriber("http://whisper-server", clientReturning("WEBVTT\n", captureRequests = requests))
+            .transcribe(wavFile(tmp))
+
+        val body = requests.single().body as okhttp3.MultipartBody
+        val partNames = body.parts.mapNotNull { it.headers?.get("Content-Disposition") }
+        assertTrue(partNames.any { it.contains("name=\"file\"") })
+        assertTrue(partNames.any { it.contains("name=\"language\"") })
+        assertTrue(partNames.any { it.contains("name=\"response_format\"") })
+    }
+
+    @Test
+    fun `transcribe returns response body on success`(@TempDir tmp: Path) {
+        val vtt = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello world\n"
+        val result = Transcriber("http://whisper-server", clientReturning(vtt)).transcribe(wavFile(tmp))
+        assertEquals(vtt, result)
+    }
+
+    @Test
+    fun `transcribe throws on non-200 response`(@TempDir tmp: Path) {
+        val ex = assertFailsWith<RuntimeException> {
+            Transcriber("http://whisper-server", clientReturning(responseCode = 500))
+                .transcribe(wavFile(tmp))
+        }
+        assertTrue(ex.message!!.contains("500"))
+    }
+
+    @Test
+    fun `transcribe throws on empty body`(@TempDir tmp: Path) {
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .build()
+                }
+                .build()
+
+        assertFailsWith<RuntimeException> {
+            Transcriber("http://whisper-server", client).transcribe(wavFile(tmp))
+        }
+    }
+}

--- a/pipeline/src/test/kotlin/com/rsstowhisper/feed/FeedServiceTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/feed/FeedServiceTest.kt
@@ -4,52 +4,146 @@ import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.IOException
+import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+private val MINIMAL_RSS =
+    """<?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <channel>
+        <title>Test Feed</title>
+        <link>https://example.com</link>
+        <description>A test feed</description>
+        <item><title>Episode One</title><link>https://example.com/ep1</link></item>
+      </channel>
+    </rss>""".trimIndent()
+
 class FeedServiceTest {
-    private fun clientCapturingHeaders(
-        captured: MutableList<String?>,
+    private fun clientReturning(
+        body: String = "",
         responseCode: Int = 200,
+        captureHeaders: MutableList<String?>? = null,
     ): OkHttpClient =
         OkHttpClient.Builder()
             .addInterceptor { chain ->
-                captured.add(chain.request().header("User-Agent"))
+                captureHeaders?.add(chain.request().header("User-Agent"))
                 Response.Builder()
                     .request(chain.request())
                     .protocol(Protocol.HTTP_1_1)
                     .code(responseCode)
                     .message(if (responseCode == 200) "OK" else "Error")
-                    .body("".toResponseBody())
+                    .body(body.toResponseBody())
                     .build()
             }
             .build()
 
+    private fun clientThrowing(exception: IOException): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor { throw exception }
+            .build()
+
+    // --- fetchFeed ---
+
     @Test
     fun `fetchFeed sends user-agent header`() {
         val headers = mutableListOf<String?>()
-        val service = FeedService(clientCapturingHeaders(headers))
-
-        service.fetchFeed("https://example.com/feed.rss")
+        FeedService(clientReturning(MINIMAL_RSS, captureHeaders = headers))
+            .fetchFeed("https://example.com/feed.rss")
 
         val userAgent = headers.single()
         assertNotNull(userAgent)
-        assertTrue(userAgent.startsWith("rss-to-whisper/"), "Expected header to start with 'rss-to-whisper/' but was: $userAgent")
-        assertTrue(userAgent.contains("github.com/baz8080/rss_to_whisper"), "Expected header to contain repo URL but was: $userAgent")
+        assertTrue(userAgent.startsWith("rss-to-whisper/"))
+        assertTrue(userAgent.contains("github.com/baz8080/rss_to_whisper"))
     }
+
+    @Test
+    fun `fetchFeed parses valid RSS and returns feed`() {
+        val feed = FeedService(clientReturning(MINIMAL_RSS)).fetchFeed("https://example.com/feed.rss")
+
+        assertNotNull(feed)
+        assertEquals("Test Feed", feed.title)
+        assertEquals(1, feed.entries.size)
+        assertEquals("Episode One", feed.entries[0].title)
+    }
+
+    @Test
+    fun `fetchFeed returns null on non-200 response`() {
+        val feed = FeedService(clientReturning(responseCode = 404)).fetchFeed("https://example.com/feed.rss")
+        assertNull(feed)
+    }
+
+    @Test
+    fun `fetchFeed returns null on network exception`() {
+        val feed = FeedService(clientThrowing(IOException("connection refused")))
+            .fetchFeed("https://example.com/feed.rss")
+        assertNull(feed)
+    }
+
+    // --- downloadAudio ---
 
     @Test
     fun `downloadAudio sends user-agent header`() {
         val headers = mutableListOf<String?>()
-        val service = FeedService(clientCapturingHeaders(headers, responseCode = 404))
-
-        service.downloadAudio("https://example.com/episode.mp3", Path.of("episode.mp3"))
+        FeedService(clientReturning(captureHeaders = headers, responseCode = 404))
+            .downloadAudio("https://example.com/episode.mp3", Path.of("episode.mp3"))
 
         val userAgent = headers.single()
         assertNotNull(userAgent)
-        assertTrue(userAgent.startsWith("rss-to-whisper/"), "Expected header to start with 'rss-to-whisper/' but was: $userAgent")
-        assertTrue(userAgent.contains("github.com/baz8080/rss_to_whisper"), "Expected header to contain repo URL but was: $userAgent")
+        assertTrue(userAgent.startsWith("rss-to-whisper/"))
+        assertTrue(userAgent.contains("github.com/baz8080/rss_to_whisper"))
+    }
+
+    @Test
+    fun `downloadAudio writes body to target path`(@TempDir tmp: Path) {
+        val target = tmp.resolve("episode.mp3")
+        FeedService(clientReturning(body = "audio-bytes")).downloadAudio("https://example.com/ep.mp3", target)
+
+        assertTrue(Files.exists(target))
+        assertEquals("audio-bytes", Files.readString(target))
+    }
+
+    @Test
+    fun `downloadAudio skips request when file already exists`(@TempDir tmp: Path) {
+        val target = tmp.resolve("episode.mp3")
+        Files.writeString(target, "existing")
+
+        var requestCount = 0
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    requestCount++
+                    Response.Builder().request(chain.request()).protocol(Protocol.HTTP_1_1)
+                        .code(200).message("OK").body("".toResponseBody()).build()
+                }
+                .build()
+
+        FeedService(client).downloadAudio("https://example.com/ep.mp3", target)
+
+        assertEquals(0, requestCount)
+        assertEquals("existing", Files.readString(target))
+    }
+
+    @Test
+    fun `downloadAudio does not create file on non-200 response`(@TempDir tmp: Path) {
+        val target = tmp.resolve("episode.mp3")
+        FeedService(clientReturning(responseCode = 503)).downloadAudio("https://example.com/ep.mp3", target)
+
+        assertTrue(Files.notExists(target))
+    }
+
+    @Test
+    fun `downloadAudio does not throw on network exception`(@TempDir tmp: Path) {
+        val target = tmp.resolve("episode.mp3")
+        FeedService(clientThrowing(IOException("timeout")))
+            .downloadAudio("https://example.com/ep.mp3", target)
+
+        assertTrue(Files.notExists(target))
     }
 }

--- a/pipeline/src/test/kotlin/com/rsstowhisper/feed/FeedServiceTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/feed/FeedServiceTest.kt
@@ -15,7 +15,8 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 private val MINIMAL_RSS =
-    """<?xml version="1.0" encoding="UTF-8"?>
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
     <rss version="2.0">
       <channel>
         <title>Test Feed</title>
@@ -23,7 +24,8 @@ private val MINIMAL_RSS =
         <description>A test feed</description>
         <item><title>Episode One</title><link>https://example.com/ep1</link></item>
       </channel>
-    </rss>""".trimIndent()
+    </rss>
+    """.trimIndent()
 
 class FeedServiceTest {
     private fun clientReturning(
@@ -81,8 +83,9 @@ class FeedServiceTest {
 
     @Test
     fun `fetchFeed returns null on network exception`() {
-        val feed = FeedService(clientThrowing(IOException("connection refused")))
-            .fetchFeed("https://example.com/feed.rss")
+        val feed =
+            FeedService(clientThrowing(IOException("connection refused")))
+                .fetchFeed("https://example.com/feed.rss")
         assertNull(feed)
     }
 
@@ -101,7 +104,9 @@ class FeedServiceTest {
     }
 
     @Test
-    fun `downloadAudio writes body to target path`(@TempDir tmp: Path) {
+    fun `downloadAudio writes body to target path`(
+        @TempDir tmp: Path,
+    ) {
         val target = tmp.resolve("episode.mp3")
         FeedService(clientReturning(body = "audio-bytes")).downloadAudio("https://example.com/ep.mp3", target)
 
@@ -110,7 +115,9 @@ class FeedServiceTest {
     }
 
     @Test
-    fun `downloadAudio skips request when file already exists`(@TempDir tmp: Path) {
+    fun `downloadAudio skips request when file already exists`(
+        @TempDir tmp: Path,
+    ) {
         val target = tmp.resolve("episode.mp3")
         Files.writeString(target, "existing")
 
@@ -131,7 +138,9 @@ class FeedServiceTest {
     }
 
     @Test
-    fun `downloadAudio does not create file on non-200 response`(@TempDir tmp: Path) {
+    fun `downloadAudio does not create file on non-200 response`(
+        @TempDir tmp: Path,
+    ) {
         val target = tmp.resolve("episode.mp3")
         FeedService(clientReturning(responseCode = 503)).downloadAudio("https://example.com/ep.mp3", target)
 
@@ -139,7 +148,9 @@ class FeedServiceTest {
     }
 
     @Test
-    fun `downloadAudio does not throw on network exception`(@TempDir tmp: Path) {
+    fun `downloadAudio does not throw on network exception`(
+        @TempDir tmp: Path,
+    ) {
         val target = tmp.resolve("episode.mp3")
         FeedService(clientThrowing(IOException("timeout")))
             .downloadAudio("https://example.com/ep.mp3", target)

--- a/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
@@ -1,0 +1,369 @@
+package com.rsstowhisper.web.db
+
+import com.rsstowhisper.web.models.SearchFilters
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class EpisodeRepositoryTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repo: EpisodeRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dbPath = tempDir.resolve("test.db").toAbsolutePath().toString()
+        DriverManager.getConnection("jdbc:sqlite:$dbPath").use { conn ->
+            createSchema(conn)
+            insertFixtures(conn)
+            conn.createStatement().execute("INSERT INTO episodes_fts(episodes_fts) VALUES('rebuild')")
+        }
+        repo = EpisodeRepository()
+        repo.dbPath = dbPath
+        repo.init()
+    }
+
+    @AfterEach
+    fun tearDown() = repo.cleanup()
+
+    // --- fixtures ---
+
+    private fun createSchema(conn: Connection) {
+        conn.createStatement().execute(
+            """CREATE TABLE episodes (
+                id TEXT PRIMARY KEY,
+                podcast_title TEXT, podcast_link TEXT, podcast_language TEXT,
+                podcast_copyright TEXT, podcast_author TEXT, podcast_image TEXT,
+                podcast_type TEXT, podcast_collections TEXT,
+                episode_title TEXT, episode_published_on TEXT,
+                episode_audio_link TEXT, episode_web_link TEXT,
+                episode_image TEXT, episode_summary TEXT, episode_subtitle TEXT,
+                episode_authors TEXT, episode_number INTEGER, episode_season INTEGER,
+                episode_type TEXT, episode_duration INTEGER,
+                episode_transcript TEXT, episode_transcript_plain TEXT,
+                episode_relative_audio_path TEXT, all_tags TEXT
+            )""",
+        )
+        conn.createStatement().execute(
+            """CREATE VIRTUAL TABLE episodes_fts USING fts5(
+                episode_title, episode_transcript_plain, podcast_title, all_tags,
+                content='episodes', content_rowid='rowid'
+            )""",
+        )
+    }
+
+    private fun insertFixtures(conn: Connection) {
+        // ep1 — Podcast A, SHORT duration, tech+science collections, kotlin+jvm tags
+        insert(
+            conn,
+            id = "ep1",
+            podcastTitle = "Podcast A",
+            episodeTitle = "Kotlin Episode",
+            publishedOn = "2024-01-01",
+            duration = 600,
+            collections = "tech, science",
+            tags = "kotlin, jvm",
+            type = "full",
+            transcriptPlain = "kotlin programming language",
+        )
+        // ep2 — Podcast A, MEDIUM duration, tech collection, java tag
+        insert(
+            conn,
+            id = "ep2",
+            podcastTitle = "Podcast A",
+            episodeTitle = "Java Episode",
+            publishedOn = "2024-01-03",
+            duration = 1800,
+            collections = "tech",
+            tags = "java",
+            type = "full",
+            transcriptPlain = "java programming",
+        )
+        // ep3 — Podcast B, LONG duration, science collection, physics tag, trailer type
+        insert(
+            conn,
+            id = "ep3",
+            podcastTitle = "Podcast B",
+            episodeTitle = "Physics Trailer",
+            publishedOn = "2024-01-02",
+            duration = 3600,
+            collections = "science",
+            tags = "physics",
+            type = "trailer",
+            transcriptPlain = "physics and quantum mechanics",
+        )
+        // ep4 — Podcast B, no duration/collections/tags/type — tests null handling
+        insert(
+            conn,
+            id = "ep4",
+            podcastTitle = "Podcast B",
+            episodeTitle = "No Duration Episode",
+            publishedOn = "2024-01-04",
+            duration = null,
+            collections = null,
+            tags = null,
+            type = null,
+            transcriptPlain = "some content here",
+        )
+    }
+
+    private fun insert(
+        conn: Connection,
+        id: String,
+        podcastTitle: String,
+        episodeTitle: String,
+        publishedOn: String,
+        duration: Int?,
+        collections: String?,
+        tags: String?,
+        type: String?,
+        transcriptPlain: String,
+    ) {
+        conn.prepareStatement(
+            """INSERT INTO episodes
+               (id, podcast_title, episode_title, episode_published_on, episode_duration,
+                podcast_collections, all_tags, episode_type,
+                episode_transcript, episode_transcript_plain, episode_relative_audio_path)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        ).use { stmt ->
+            stmt.setString(1, id)
+            stmt.setString(2, podcastTitle)
+            stmt.setString(3, episodeTitle)
+            stmt.setString(4, publishedOn)
+            stmt.setObject(5, duration)
+            stmt.setObject(6, collections)
+            stmt.setObject(7, tags)
+            stmt.setObject(8, type)
+            stmt.setString(9, "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n$transcriptPlain\n")
+            stmt.setString(10, transcriptPlain)
+            stmt.setString(11, "$id/audio.wav")
+            stmt.execute()
+        }
+    }
+
+    // --- tests ---
+
+    @Nested
+    inner class Search {
+        @Test
+        fun `no query returns all episodes ordered by published date descending`() {
+            val result = repo.search(SearchFilters())
+            assertEquals(4, result.totalCount)
+            assertEquals(listOf("ep4", "ep2", "ep3", "ep1"), result.episodes.map { it.id })
+        }
+
+        @Test
+        fun `query filters by FTS and returns snippet`() {
+            val result = repo.search(SearchFilters(query = "kotlin"))
+            assertEquals(1, result.totalCount)
+            assertEquals("ep1", result.episodes.single().id)
+            assertNotNull(result.episodes.single().snippet)
+        }
+
+        @Test
+        fun `query matching multiple episodes returns all matches`() {
+            val result = repo.search(SearchFilters(query = "programming"))
+            assertEquals(2, result.totalCount)
+            val ids = result.episodes.map { it.id }.toSet()
+            assertTrue("ep1" in ids)
+            assertTrue("ep2" in ids)
+        }
+
+        @Test
+        fun `no-query results have null snippet`() {
+            assertTrue(repo.search(SearchFilters()).episodes.all { it.snippet == null })
+        }
+
+        @Nested
+        inner class DurationFilter {
+            @Test
+            fun `SHORT returns episodes under 900 seconds`() {
+                val result = repo.search(SearchFilters(durations = setOf("SHORT")))
+                assertEquals(1, result.totalCount)
+                assertEquals("ep1", result.episodes.single().id)
+            }
+
+            @Test
+            fun `MEDIUM returns episodes between 900 and 2700 seconds`() {
+                val result = repo.search(SearchFilters(durations = setOf("MEDIUM")))
+                assertEquals(1, result.totalCount)
+                assertEquals("ep2", result.episodes.single().id)
+            }
+
+            @Test
+            fun `LONG returns episodes over 2700 seconds`() {
+                val result = repo.search(SearchFilters(durations = setOf("LONG")))
+                assertEquals(1, result.totalCount)
+                assertEquals("ep3", result.episodes.single().id)
+            }
+
+            @Test
+            fun `multiple duration categories are ORed`() {
+                val result = repo.search(SearchFilters(durations = setOf("SHORT", "LONG")))
+                assertEquals(2, result.totalCount)
+                val ids = result.episodes.map { it.id }.toSet()
+                assertTrue("ep1" in ids)
+                assertTrue("ep3" in ids)
+            }
+
+            @Test
+            fun `null duration is excluded by all duration filters`() {
+                for (cat in listOf("SHORT", "MEDIUM", "LONG")) {
+                    val result = repo.search(SearchFilters(durations = setOf(cat)))
+                    assertFalse(result.episodes.any { it.id == "ep4" }, "ep4 should not appear for $cat")
+                }
+            }
+        }
+
+        @Nested
+        inner class PodcastFilter {
+            @Test
+            fun `single podcast restricts results`() {
+                val result = repo.search(SearchFilters(podcasts = setOf("Podcast A")))
+                assertEquals(2, result.totalCount)
+                assertTrue(result.episodes.all { it.podcastTitle == "Podcast A" })
+            }
+
+            @Test
+            fun `multiple podcasts are ORed`() {
+                val result = repo.search(SearchFilters(podcasts = setOf("Podcast A", "Podcast B")))
+                assertEquals(4, result.totalCount)
+            }
+        }
+
+        @Nested
+        inner class CollectionsFilter {
+            @Test
+            fun `collections filter matches episodes containing that collection`() {
+                val result = repo.search(SearchFilters(collections = setOf("science")))
+                assertEquals(2, result.totalCount)
+                val ids = result.episodes.map { it.id }.toSet()
+                assertTrue("ep1" in ids)
+                assertTrue("ep3" in ids)
+            }
+        }
+
+        @Nested
+        inner class TagsFilter {
+            @Test
+            fun `tags filter matches episodes containing that tag`() {
+                val result = repo.search(SearchFilters(tags = setOf("kotlin")))
+                assertEquals(1, result.totalCount)
+                assertEquals("ep1", result.episodes.single().id)
+            }
+        }
+
+        @Nested
+        inner class EpisodeTypeFilter {
+            @Test
+            fun `episode type filter restricts to that type`() {
+                val result = repo.search(SearchFilters(episodeTypes = setOf("trailer")))
+                assertEquals(1, result.totalCount)
+                assertEquals("ep3", result.episodes.single().id)
+            }
+        }
+
+        @Nested
+        inner class Pagination {
+            @Test
+            fun `first page returns up to pageSize results`() {
+                val result = repo.search(SearchFilters(page = 1, pageSize = 2))
+                assertEquals(2, result.episodes.size)
+                assertEquals(4, result.totalCount)
+            }
+
+            @Test
+            fun `second page returns the remaining results`() {
+                val page1Ids = repo.search(SearchFilters(page = 1, pageSize = 2)).episodes.map { it.id }.toSet()
+                val page2Ids = repo.search(SearchFilters(page = 2, pageSize = 2)).episodes.map { it.id }.toSet()
+                assertTrue(page1Ids.intersect(page2Ids).isEmpty())
+                assertEquals(4, (page1Ids + page2Ids).size)
+            }
+
+            @Test
+            fun `page beyond available results returns empty episode list with correct total`() {
+                val result = repo.search(SearchFilters(page = 99, pageSize = 10))
+                assertTrue(result.episodes.isEmpty())
+                assertEquals(4, result.totalCount)
+            }
+        }
+    }
+
+    @Nested
+    inner class GetEpisodeById {
+        @Test
+        fun `returns episode with correct fields`() {
+            val episode = repo.getEpisodeById("ep1")!!
+            assertEquals("ep1", episode.id)
+            assertEquals("Podcast A", episode.podcastTitle)
+            assertEquals("Kotlin Episode", episode.episodeTitle)
+        }
+
+        @Test
+        fun `includes transcript`() {
+            val transcript = repo.getEpisodeById("ep1")!!.transcript!!
+            assertTrue(transcript.startsWith("WEBVTT"))
+        }
+
+        @Test
+        fun `returns null for unknown id`() {
+            assertNull(repo.getEpisodeById("nonexistent"))
+        }
+    }
+
+    @Nested
+    inner class GetFilterOptions {
+        @Test
+        fun `returns all distinct podcast titles sorted`() {
+            val options = repo.getFilterOptions("")
+            assertEquals(listOf("Podcast A", "Podcast B"), options.podcasts)
+        }
+
+        @Test
+        fun `returns collections split from CSV and sorted`() {
+            val options = repo.getFilterOptions("")
+            assertEquals(listOf("science", "tech"), options.collections)
+        }
+
+        @Test
+        fun `returns distinct episode types`() {
+            val options = repo.getFilterOptions("")
+            assertEquals(listOf("full", "trailer"), options.episodeTypes)
+        }
+
+        @Test
+        fun `scopes results to FTS matches when query is provided`() {
+            val options = repo.getFilterOptions("kotlin")
+            assertEquals(listOf("Podcast A"), options.podcasts)
+        }
+
+        @Test
+        fun `second call with same query returns cached object`() {
+            val first = repo.getFilterOptions("kotlin")
+            val second = repo.getFilterOptions("kotlin")
+            assertSame(first, second)
+        }
+
+        @Test
+        fun `different query bypasses cache and re-queries`() {
+            val forKotlin = repo.getFilterOptions("kotlin")
+            val forPhysics = repo.getFilterOptions("physics")
+            assertNotSame(forKotlin, forPhysics)
+            assertEquals(listOf("Podcast A"), forKotlin.podcasts)
+            assertEquals(listOf("Podcast B"), forPhysics.podcasts)
+        }
+    }
+}

--- a/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
@@ -2,13 +2,6 @@ package com.rsstowhisper.web.db
 
 import com.rsstowhisper.web.models.SearchFilters
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
-import java.nio.file.Path
-import java.sql.Connection
-import java.sql.DriverManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -16,6 +9,13 @@ import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.sql.Connection
+import java.sql.DriverManager
 
 class EpisodeRepositoryTest {
     @TempDir


### PR DESCRIPTION
## Summary

- **Fix regression**: `PIPELINE_CONFIG_PATH` was not being resolved because `File(\".env\")` resolved against the Gradle working directory (project root), not `pipeline/`. Fixed by using `File(\"pipeline/.env\")` explicitly.
- **Consolidate config loading**: All env var reading (`PIPELINE_CONFIG_PATH`, `PIPELINE_DATA_DIRECTORY`, `PIPELINE_WHISPER_SERVER_URL`, `PIPELINE_VERBOSE`) now lives in `AppConfig.load()`. `Main.kt` just calls `AppConfig.load()` with no knowledge of env vars.
- **Move `verbose` to `.env`**: It's a runtime switch, not stable feed config — consistent with how the other vars are treated.
- **Remove `-c`/`--config` CLI flag**: Config path always comes from `.env`.
- **Remove `@JsonProperty` annotation**: Configuring Jackson with `SNAKE_CASE` naming strategy handles the mapping universally.
- **Make `Transcriber` injectable**: Accepts an `OkHttpClient` parameter (default: production timeouts), matching `FeedService` and enabling testing.
- **New tests**: `AppConfigTest`, expanded `FeedServiceTest`, `TranscriberTest`, `EpisodeRepositoryTest` (the entire DB layer was previously untested).

## Test plan

- [x] `./gradlew test` passes
- [x] `./gradlew :pipeline:run` resolves config from `pipeline/.env` correctly
- [x] `PIPELINE_VERBOSE=true` in `.env` enables debug logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)