### PR TITLE
Sticky audio player and keyboard shortcuts on episode detail page

### DIFF
--- a/web/src/main/resources/META-INF/resources/styles.css
+++ b/web/src/main/resources/META-INF/resources/styles.css
@@ -110,7 +110,13 @@ body {
     font-size: 0.85rem;
 }
 .audio-player {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--pico-background-color, #fff);
+    padding: 0.5rem 0;
     margin-top: 0.5rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
 }
 .audio-player audio {
     width: 100%;

--- a/web/src/main/resources/templates/episode.html
+++ b/web/src/main/resources/templates/episode.html
@@ -158,6 +158,22 @@
             }
             return result;
         }
+
+        document.addEventListener('keydown', function (e) {
+            const tag = document.activeElement.tagName;
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+            if (!audioEl) return;
+            if (e.key === ' ') {
+                e.preventDefault();
+                audioEl.paused ? audioEl.play() : audioEl.pause();
+            } else if (e.key === 'ArrowLeft') {
+                e.preventDefault();
+                audioEl.currentTime = Math.max(0, audioEl.currentTime - 15);
+            } else if (e.key === 'ArrowRight') {
+                e.preventDefault();
+                audioEl.currentTime = Math.min(audioEl.duration || Infinity, audioEl.currentTime + 15);
+            }
+        });
         /*]]>*/
     </script>
 


### PR DESCRIPTION
## Summary

- The audio player on the episode detail page is now `position: sticky`, locking to the top of the viewport once scrolled to, so the transcript can be read while the player stays visible. Scrolling back to the top returns it to its natural position.
- Keyboard shortcuts added (active when no text input is focused):
  - `Space` — play / pause
  - `←` — rewind 15 seconds
  - `→` — skip forward 15 seconds

## Test plan

- [x] Open an episode with a long transcript and scroll down — player should stick to the top of the viewport
- [x] Scroll back to the top — player should return to its natural position in the page flow
- [x] Press `Space` to play and pause audio
- [x] Press `←` / `→` to seek ±15 seconds
- [x] Click into a text input and confirm keyboard shortcuts do not fire

🤖 Generated with [Claude Code](https://claude.ai/claude-code)