### PR TITLE
Send an initial prompt, and switch to large-v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,20 @@ It is highly recommended to also download a [VAD model](https://github.com/ggml-
 
 ```bash
 whisper-server \
-  -m models/ggml-large-v3-turbo.bin \
+  -m models/ggml-large-v3.bin \
   --vad -vm models/ggml-silero-v5.1.2.bin
 ```
+
+#### Model: large-v3, not large-v3-turbo
+
+Turbo prunes the **decoder** and keeps the encoder, and with Core ML the encoder
+runs on the Neural Engine — which is where most of the wall clock goes. Measured
+over 13 episodes, large-v3 costs **1.36x** turbo's decode time, not the 2-3x that
+"turbo for speed" assumes, and it produced a usable transcript on 10 of 13
+episodes that turbo could not decode at all.
+
+Put `ggml-large-v3-encoder.mlmodelc` next to the `.bin` or the encoder silently
+falls back off the ANE and the speed gap gets much worse.
 
 #### Why
 
@@ -105,6 +116,37 @@ The threshold only matters in the tail, and **the optimum is episode-dependent**
 It is not VAD as such. On one episode, threshold 0.2 gave 0.0000 punctuation-per-word and 0.5 gave 0.1982 — and VAD *off* also gave 0.0000. More non-speech reaching the decoder makes the degraded mode likelier, and how much non-speech an episode contains varies.
 
 **Do not tune per show.** 
+
+#### Set an initial prompt
+
+Whisper intermittently decodes an entire episode with **no punctuation and no
+capitals**. It is not cosmetic: whisper segments on sentence structure, so with
+no full stops the cue boundaries stop tracking speech and every timestamp
+derived from them is unreliable. 654 episodes were hit, and 13 resisted every
+attempt to re-decode them.
+
+An `initial_prompt` of ordinary punctuated prose fixed **all 13**:
+
+| approach | fixed |
+|---|---|
+| **initial_prompt** | **13 / 13** |
+| whisper large-v3 | 10 / 13 |
+| best VAD parameter | 9 / 13 |
+| Silero VAD v6.2.0 | 6 / 13 |
+| re-decode at another threshold | 0 / 13 |
+
+This is a **decoder** mode, not a segmentation problem, which is why no VAD
+setting touched it — VAD only changes what audio reaches the decoder, while a
+prompt conditions the decoder itself, and punctuation is a style.
+
+Send `carry_initial_prompt=true` as well. Without it the prompt conditions only
+the first window and an episode that degrades later still degrades (13/13 with,
+12/13 without).
+
+Keep the prompt generic. An initial prompt biases **vocabulary** as well as
+style, so anything domain-specific will contaminate transcripts. The default in
+`Transcriber.kt` was checked on a repaired episode: zero occurrences of any
+prompt fragment, word count within 5% of the original.
 
 #### TODO: Detect and retry instead
 

--- a/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
@@ -27,6 +27,33 @@ open class Transcriber(
      * it only bites on the runaway cases.
      */
     private val maxLen: Int = DEFAULT_MAX_LEN,
+    /**
+     * Whisper's `initial_prompt`, carried into every decode window.
+     *
+     * Whisper intermittently drops into a mode where it emits no punctuation
+     * and no capitals for an entire episode. That is not cosmetic: it segments
+     * on sentence structure, so with no full stops the cue boundaries stop
+     * tracking speech and every timestamp derived from them is unreliable. It
+     * hit 654 episodes, and 13 survived every attempt to re-decode them.
+     *
+     * An initial prompt fixed **all 13**. Measured on the same set:
+     *
+     *   initial_prompt      13/13
+     *   whisper large-v3    10/13
+     *   best VAD parameter   9/13
+     *   Silero VAD v6.2.0    6/13
+     *   another threshold    0/13
+     *
+     * It works because this is a DECODER mode, not a segmentation problem --
+     * every VAD setting only changes what audio reaches the decoder, while a
+     * prompt conditions the decoder itself, and punctuation is a style.
+     *
+     * Deliberately generic prose. An initial prompt biases VOCABULARY as well
+     * as style, so anything domain-specific would contaminate transcripts.
+     * Verified on a repaired episode: zero occurrences of any prompt fragment,
+     * word count within 5% of the original.
+     */
+    private val initialPrompt: String = DEFAULT_INITIAL_PROMPT,
 ) {
     private val logger = LoggerFactory.getLogger(Transcriber::class.java)
 
@@ -36,7 +63,7 @@ open class Transcriber(
      * go straight up without a local ffmpeg pass.
      */
     open fun transcribe(audioPath: Path): String {
-        val requestBody =
+        val bodyBuilder =
             MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart(
@@ -53,7 +80,17 @@ open class Transcriber(
                 .addFormDataPart("max_len", maxLen.toString())
                 // Cut on word boundaries rather than mid-token.
                 .addFormDataPart("split_on_word", "true")
-                .build()
+
+        if (initialPrompt.isNotBlank()) {
+            bodyBuilder.addFormDataPart("prompt", initialPrompt)
+            // Without this the prompt conditions only the FIRST window, so an
+            // episode that degrades part-way through still degrades -- which is
+            // exactly what a whole-episode failure looks like. 13/13 fixed with
+            // it, 12/13 without.
+            bodyBuilder.addFormDataPart("carry_initial_prompt", "true")
+        }
+
+        val requestBody = bodyBuilder.build()
 
         val request =
             Request.Builder()
@@ -73,5 +110,10 @@ open class Transcriber(
 
     companion object {
         const val DEFAULT_MAX_LEN = 200
+
+        /** See [initialPrompt]. Ordinary punctuated prose, nothing domain-specific. */
+        const val DEFAULT_INITIAL_PROMPT =
+            "Hello, and welcome back to the show. Today we're going to talk about " +
+                "a few different things, and I think you'll enjoy it. Let's get started."
     }
 }

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
@@ -99,6 +99,41 @@ class TranscriberTest {
         assertEquals("true", fields["split_on_word"])
     }
 
+    /**
+     * The prompt is what fixed all 13 episodes that no VAD setting could, and
+     * `carry_initial_prompt` is what makes it apply past the first window --
+     * 13/13 with it, 12/13 without. They have to travel together.
+     */
+    @Test
+    fun `transcribe sends an initial prompt and carries it across windows`(
+        @TempDir tmp: Path,
+    ) {
+        val requests = mutableListOf<okhttp3.Request>()
+        Transcriber("http://whisper-server", httpClient = clientReturning("WEBVTT\n", captureRequests = requests))
+            .transcribe(mp3File(tmp))
+
+        val fields = formFields(requests.single().body as okhttp3.MultipartBody)
+        assertEquals(Transcriber.DEFAULT_INITIAL_PROMPT, fields["prompt"])
+        assertEquals("true", fields["carry_initial_prompt"])
+    }
+
+    /**
+     * An initial prompt biases vocabulary as well as style, so it has to be
+     * possible to turn off without editing the class.
+     */
+    @Test
+    fun `transcribe omits the prompt fields when the prompt is blank`(
+        @TempDir tmp: Path,
+    ) {
+        val requests = mutableListOf<okhttp3.Request>()
+        Transcriber("http://whisper-server", initialPrompt = "", httpClient = clientReturning("WEBVTT\n", captureRequests = requests))
+            .transcribe(mp3File(tmp))
+
+        val fields = formFields(requests.single().body as okhttp3.MultipartBody)
+        assertEquals(null, fields["prompt"])
+        assertEquals(null, fields["carry_initial_prompt"])
+    }
+
     @Test
     fun `transcribe honours a custom max length`(
         @TempDir tmp: Path,


### PR DESCRIPTION
Whisper intermittently decodes a whole episode with no punctuation and no capitals. It is not cosmetic -- whisper segments on sentence structure, so with no full stops the cue boundaries stop tracking speech and every timestamp derived from them is unreliable. 654 episodes were hit, and 13 resisted every attempt to re-decode them.

An initial_prompt of ordinary punctuated prose fixed all 13. Measured on that same set:

    initial_prompt                  13/13
    whisper large-v3                10/13
    best VAD parameter               9/13
    Silero VAD v6.2.0                6/13
    re-decode at another threshold   0/13

This is a DECODER mode, not a segmentation problem, which is why no VAD setting ever touched it: VAD changes what audio reaches the decoder, a prompt conditions the decoder itself, and punctuation is a style.

carry_initial_prompt travels with it -- without it the prompt conditions only the first window and an episode that degrades later still degrades (13/13 with, 12/13 without). The prompt is deliberately generic because an initial prompt biases vocabulary as well as style; verified on a repaired episode as zero prompt fragments and word count within 5% of the original. Blank prompt omits both fields.

README now recommends large-v3 over large-v3-turbo. Turbo prunes the decoder and keeps the encoder, and with Core ML the encoder runs on the ANE where most of the wall clock goes -- measured 1.36x decode time, not the 2-3x that "turbo for speed" assumes.