### PR TITLE
Fix pipeline, search, and indexer bugs found in an outside review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,44 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
+
+  indexer:
+    name: Check index.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Byte-compile
+        run: python3 -m py_compile index.py
+
+      # Runs against a two-episode fixture generated here -- never the real
+      # corpus. Covers the stdlib-sqlite3 fallback (no pysqlite3 on the runner),
+      # the FTS5 preflight, the missing-_id skip, and a round-trip FTS query.
+      - name: Smoke-test against a synthetic data directory
+        run: |
+          set -euo pipefail
+          mkdir -p fixture/Show/ep1 fixture/Show/ep2
+          cat > fixture/Show/ep1/transcript.json <<'JSON'
+          {"_id": "ep1", "podcast_title": "Show", "episode_title": "Kotlin episode",
+           "episode_transcript": "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nkotlin coroutines.\n"}
+          JSON
+          cat > fixture/Show/ep2/transcript.json <<'JSON'
+          {"podcast_title": "Show", "episode_title": "Missing id",
+           "episode_transcript": "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nshould be skipped.\n"}
+          JSON
+          python3 index.py fixture
+          python3 - <<'PY'
+          import sqlite3
+          c = sqlite3.connect("fixture/podcasts.db")
+          ids = [r[0] for r in c.execute("SELECT id FROM episodes")]
+          assert ids == ["ep1"], f"expected only ep1, got {ids}"
+          assert c.execute("SELECT count(*) FROM episodes WHERE id IS NULL").fetchone()[0] == 0
+          hits = c.execute("SELECT episode_title FROM episodes_fts WHERE episodes_fts MATCH 'coroutines'").fetchall()
+          assert hits == [("Kotlin episode",)], f"unexpected FTS result: {hits}"
+          print("index.py smoke test passed")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on: [push, pull_request]
 
+# All three jobs only check out code and run builds, so the default
+# GITHUB_TOKEN is narrowed to read-only at the top level.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .gradle/
 build/
 
+# Kotlin compiler working directory
+.kotlin/
+
 # Kotlin/JVM
 *.class
 *.jar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ No external tools are required on `PATH` — transcription is HTTP-only against 
 python3 index.py /path/to/data_directory [--db /path/to/podcasts.db]
 ```
 
-Requires `pysqlite3` (the system `sqlite3` may lack FTS5 support).
+Requires an FTS5-capable SQLite. The script prefers `pysqlite3` and falls back to the
+stdlib `sqlite3` module, exiting with a clear error if neither build has FTS5.
 
 Run this after the pipeline has produced new transcripts.
 

--- a/README.md
+++ b/README.md
@@ -247,10 +247,12 @@ Copy `pipeline/.env.example` to `pipeline/.env` and fill in your values (`.env` 
 PIPELINE_DATA_DIRECTORY=/path/to/download-directory
 PIPELINE_WHISPER_SERVER_URL=http://localhost:8080
 PIPELINE_CONFIG_PATH=/path/to/pods.yaml
-PIPELINE_VERBOSE=false
+#PIPELINE_VERBOSE=true
 ```
 
-`PIPELINE_VERBOSE` is optional; when set it overrides the `verbose` value from `pods.yaml`.
+`PIPELINE_VERBOSE` is optional; when set to a non-blank value it overrides the `verbose` value from
+`pods.yaml`. Leave it commented out (or blank) to let `pods.yaml` decide — note that any value other
+than `true` counts as `false`, so `PIPELINE_VERBOSE=false` will override `verbose: true`.
 
 The `.env` file is resolved relative to the working directory: `pipeline/.env` is tried
 first (running from the repo root), then `./.env` (running from inside `pipeline/`, or

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Quarkus HTTP server that serves a full-text search interface over the SQLite d
 ### `index.py`
 Reads all `transcript.json` files in the data directory and writes them into a SQLite FTS5 database. Run this after the pipeline to make new transcripts searchable.
 
-Requires Python 3 and `pysqlite3` with FTS5 support:
+Requires Python 3 with an FTS5-capable SQLite. The script prefers `pysqlite3` when installed and falls back to the standard library `sqlite3` module otherwise, exiting with a clear error if neither has FTS5:
 
 ```bash
 pip install pysqlite3
@@ -28,7 +28,7 @@ pip install pysqlite3
 
 - JDK 21+
 - A running [whisper.cpp HTTP server](#running-the-whispercpp-server)
-- Python 3 + `pysqlite3` (for the indexing script)
+- Python 3 with an FTS5-capable SQLite (for the indexing script; `pip install pysqlite3` if the system build lacks FTS5)
 
 No `ffmpeg` is required. MP3s are uploaded as-is and the whisper.cpp server decodes them with its
 built-in miniaudio decoder, resampling to 16 kHz mono internally. The one exception is starting the
@@ -176,17 +176,17 @@ Acceleration is determined by how the whisper.cpp `server` binary was compiled:
 
 ## Transcribing
 
-The pipeline requires a config file path, supplied either via `--config` or via `PIPELINE_CONFIG_PATH` in `pipeline/.env` (see [Pipeline configuration](#pipeline-configuration) below).
+All pipeline configuration comes from `pipeline/.env` — there are no command-line arguments (see [Pipeline configuration](#pipeline-configuration) below).
 
 ```bash
-./gradlew :pipeline:run --args="-c /path/to/pods.yaml"
+./gradlew :pipeline:run
 ```
 
 Or build and run the distribution:
 
 ```bash
 ./gradlew :pipeline:installDist
-./pipeline/build/install/pipeline/bin/pipeline -c /path/to/pods.yaml
+./pipeline/build/install/pipeline/bin/pipeline
 ```
 
 ## Indexing
@@ -247,13 +247,18 @@ Copy `pipeline/.env.example` to `pipeline/.env` and fill in your values (`.env` 
 PIPELINE_DATA_DIRECTORY=/path/to/download-directory
 PIPELINE_WHISPER_SERVER_URL=http://localhost:8080
 PIPELINE_CONFIG_PATH=/path/to/pods.yaml
+PIPELINE_VERBOSE=false
 ```
 
-`PIPELINE_CONFIG_PATH` can be overridden at runtime with `--config` / `-c`.
+`PIPELINE_VERBOSE` is optional; when set it overrides the `verbose` value from `pods.yaml`.
+
+The `.env` file is resolved relative to the working directory: `pipeline/.env` is tried
+first (running from the repo root), then `./.env` (running from inside `pipeline/`, or
+next to an installed distribution).
 
 ### `pods.yaml`
 
-- `verbose` — enable debug logging (optional, default `false`)
+- `verbose` — enable debug logging (optional, default `false`; overridden by `PIPELINE_VERBOSE` when that is set)
 - `skip_after_consecutive` — stop walking a feed once this many consecutive already-transcribed episodes are seen (optional, default `20`)
 - `podcasts` — list of RSS feeds to process, each with `name`, `url`, optional `collections`, and optional `excludes`
 

--- a/index.py
+++ b/index.py
@@ -13,9 +13,15 @@ import argparse
 import json
 import os
 import re
-import pysqlite3 as sqlite3
 import sys
 import time
+
+try:
+    import pysqlite3 as sqlite3
+except ImportError:
+    # Fall back to the stdlib module — fine anywhere its SQLite has FTS5
+    # (checked at startup in main()).
+    import sqlite3
 
 
 SCHEMA_EPISODES = """
@@ -129,6 +135,9 @@ def collect_episodes(data_dir):
                 continue
 
             episode_id = episode.get("_id")
+            if not episode_id:
+                print(f"  WARNING: Skipping {json_path}: missing _id", file=sys.stderr)
+                continue
 
             yield {
                 "id": episode_id,
@@ -177,6 +186,18 @@ def main():
     print(f"Database: {db_path}")
 
     conn = sqlite3.connect(db_path)
+
+    try:
+        conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS _fts5_check USING fts5(x)")
+        conn.execute("DROP TABLE IF EXISTS _fts5_check")
+    except sqlite3.OperationalError:
+        print(
+            "ERROR: This SQLite build has no FTS5 support. Install pysqlite3: pip install pysqlite3",
+            file=sys.stderr,
+        )
+        conn.close()
+        sys.exit(1)
+
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA foreign_keys=ON")
@@ -190,14 +211,23 @@ def main():
     if fts_exists:
         try:
             conn.execute("DROP TABLE IF EXISTS episodes_fts")
-        except sqlite3.OperationalError:
-            # FTS module not available; delete shadow tables and master entry manually.
-            # FTS5 shadow suffixes: data, idx, content, docsize, config
-            # FTS4 shadow suffixes (kept for legacy dbs): segments, segdir, stat
-            for suffix in ["data", "idx", "content", "docsize", "config",
-                           "segments", "segdir", "stat"]:
-                conn.execute(f"DROP TABLE IF EXISTS episodes_fts_{suffix}")
-            conn.execute("DELETE FROM sqlite_master WHERE name='episodes_fts'")
+        except sqlite3.OperationalError as e:
+            # The existing episodes_fts was built by an FTS module this SQLite
+            # cannot load (e.g. a legacy FTS4 table under an FTS5-only build),
+            # so DROP TABLE cannot take it apart. Editing sqlite_master by hand
+            # is not an option: the Python sqlite3 module refuses writes to it
+            # even with PRAGMA writable_schema=ON (unlike the sqlite3 CLI), and
+            # dropping only the shadow tables would leave a dangling schema
+            # entry that breaks the CREATE VIRTUAL TABLE below. Rebuilding from
+            # scratch is safe here -- the database is derived data, rebuilt in
+            # full on every run.
+            print(
+                f"ERROR: Cannot drop the existing episodes_fts table: {e}\n"
+                f"       Delete {db_path} and re-run to rebuild from scratch.",
+                file=sys.stderr,
+            )
+            conn.close()
+            sys.exit(1)
     conn.execute("DROP TABLE IF EXISTS episodes")
     conn.execute(SCHEMA_EPISODES)
     conn.commit()

--- a/index.py
+++ b/index.py
@@ -202,6 +202,18 @@ def main():
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA foreign_keys=ON")
 
+    # Collect before dropping anything. The rebuild below is destructive and
+    # episodes_fts is only recreated at the very end, so bailing out after the
+    # drops would leave a previously working database truncated and without its
+    # FTS index -- and every episode can be skipped legitimately (e.g. none of
+    # the transcript.json files carry an _id).
+    episodes = list(collect_episodes(args.data_dir))
+
+    if not episodes:
+        print("Nothing to index; leaving the existing database untouched")
+        conn.close()
+        return
+
     # Use raw sqlite_master to drop FTS table safely — DROP TABLE on a
     # virtual table requires the module to be loaded, which may not be
     # available if the table was created with a different FTS version.
@@ -231,13 +243,6 @@ def main():
     conn.execute("DROP TABLE IF EXISTS episodes")
     conn.execute(SCHEMA_EPISODES)
     conn.commit()
-
-    episodes = list(collect_episodes(args.data_dir))
-
-    if not episodes:
-        print("Nothing to index")
-        conn.close()
-        return
 
     t0 = time.time()
     print(f"Inserting {len(episodes)} episodes...")

--- a/pipeline/.env.example
+++ b/pipeline/.env.example
@@ -1,4 +1,6 @@
 PIPELINE_DATA_DIRECTORY=/path/to/download-directory
 PIPELINE_WHISPER_SERVER_URL=http://localhost:8080
 PIPELINE_CONFIG_PATH=/path/to/pods.yaml
-PIPELINE_VERBOSE=false
+# Optional; when set it overrides `verbose` in pods.yaml. Leave commented out
+# to let pods.yaml decide.
+#PIPELINE_VERBOSE=true

--- a/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
@@ -34,7 +34,9 @@ data class AppConfig(
             val whisperServerUrl =
                 env["PIPELINE_WHISPER_SERVER_URL"]
                     ?: error("PIPELINE_WHISPER_SERVER_URL must be set in .env")
-            val verbose = env["PIPELINE_VERBOSE"]?.toBoolean()
+            // Blank means "not set" -- an empty PIPELINE_VERBOSE= line must fall
+            // through to pods.yaml rather than forcing it off via toBoolean().
+            val verbose = env["PIPELINE_VERBOSE"]?.takeIf { it.isNotBlank() }?.toBoolean()
 
             val raw: AppConfig = mapper.readValue(File(configPath))
             return raw.copy(

--- a/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
@@ -34,15 +34,22 @@ data class AppConfig(
             val whisperServerUrl =
                 env["PIPELINE_WHISPER_SERVER_URL"]
                     ?: error("PIPELINE_WHISPER_SERVER_URL must be set in .env")
-            val verbose = env["PIPELINE_VERBOSE"]?.toBoolean() ?: false
+            val verbose = env["PIPELINE_VERBOSE"]?.toBoolean()
 
             val raw: AppConfig = mapper.readValue(File(configPath))
-            return raw.copy(dataDirectory = dataDirectory, whisperServerUrl = whisperServerUrl, verbose = verbose)
+            return raw.copy(
+                dataDirectory = dataDirectory,
+                whisperServerUrl = whisperServerUrl,
+                verbose = verbose ?: raw.verbose,
+            )
         }
 
         internal fun loadDotEnv(): Map<String, String> {
-            val file = File("pipeline/.env")
-            if (!file.exists()) return emptyMap()
+            // Support running from the repo root or from inside pipeline/ (e.g. installDist).
+            val file =
+                sequenceOf(File("pipeline/.env"), File(".env"))
+                    .firstOrNull { it.exists() }
+                    ?: return emptyMap()
             return loadDotEnv(file.readText())
         }
 

--- a/pipeline/src/main/kotlin/com/rsstowhisper/feed/FeedService.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/feed/FeedService.kt
@@ -43,13 +43,14 @@ open class FeedService(private val httpClient: OkHttpClient = OkHttpClient()) {
         }
     }
 
+    /** Downloads [url] to [targetPath]. Returns true when the file is present on disk. */
     open fun downloadAudio(
         url: String,
         targetPath: Path,
-    ) {
+    ): Boolean {
         if (Files.exists(targetPath)) {
             logger.debug("Audio is already downloaded")
-            return
+            return true
         }
 
         logger.debug("Downloading audio")
@@ -67,13 +68,13 @@ open class FeedService(private val httpClient: OkHttpClient = OkHttpClient()) {
             httpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     logger.error("Error saving file response: ${response.code}")
-                    return
+                    return false
                 }
 
                 val body = response.body
                 if (body == null) {
                     logger.error("No response body for $url")
-                    return
+                    return false
                 }
 
                 logger.debug("Writing... {}", targetPath)
@@ -85,8 +86,10 @@ open class FeedService(private val httpClient: OkHttpClient = OkHttpClient()) {
             }
 
             Files.move(partialPath, targetPath, StandardCopyOption.ATOMIC_MOVE)
+            return true
         } catch (e: Exception) {
             logger.error("Failed to download $url", e)
+            return false
         } finally {
             runCatching { Files.deleteIfExists(partialPath) }
         }

--- a/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
@@ -280,18 +280,28 @@ class PodcastPipeline(
 
         private data class AudioSource(val url: String, val length: Long)
 
-        // Single source of truth for locating an episode's audio: mp3 enclosure
-        // first, then a link that is either mp3-typed or rel="enclosure". Keeping
-        // one predicate means findAudioLink and getMp3Info can never disagree
-        // about whether an episode has audio.
+        // Single source of truth for locating an episode's audio, in strict
+        // preference order: mp3 enclosure, then mp3-typed link, then a link that
+        // declares itself an enclosure without saying what it is. Keeping one
+        // predicate means findAudioLink and getMp3Info can never disagree about
+        // whether an episode has audio.
+        //
+        // The last fallback is deliberately limited to *untyped* links. A link
+        // that says rel="enclosure" type="video/mp4" is telling us it is not
+        // audio; downloading it as audio.mp3 would leave a file whisper cannot
+        // decode on disk, and since the file's presence is what marks a download
+        // as done, every later run would re-upload and re-transcribe it forever.
         private fun findAudioSource(entry: SyndEntry): AudioSource? {
             entry.enclosures
                 .firstOrNull { it.type in AUDIO_MP3_TYPES }
                 ?.let { return AudioSource(it.url, it.length) }
 
-            return entry.links
-                .firstOrNull { it.type in AUDIO_MP3_TYPES || it.rel == "enclosure" }
-                ?.let { AudioSource(it.href, it.length) }
+            val links = entry.links.orEmpty()
+            val link =
+                links.firstOrNull { it.type in AUDIO_MP3_TYPES }
+                    ?: links.firstOrNull { it.rel == "enclosure" && it.type.isNullOrBlank() }
+
+            return link?.let { AudioSource(it.href, it.length) }
         }
 
         private fun findAudioLink(entry: SyndEntry): String? = findAudioSource(entry)?.url

--- a/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
@@ -116,7 +116,10 @@ class PodcastPipeline(
                     continue
                 }
 
-                feedService.downloadAudio(mp3Info.url, mp3Info.filePath)
+                if (!feedService.downloadAudio(mp3Info.url, mp3Info.filePath)) {
+                    logger.warn("Could not download audio for $title. Skipping")
+                    continue
+                }
                 val vtt = transcribeEpisode(mp3Info, episodeDirPath)
                 writeEpisodeJson(feed, entry, mp3Info, episodeDirPath, podcast.collections, vtt)
             } catch (e: Exception) {
@@ -136,7 +139,10 @@ class PodcastPipeline(
     ) {
         val jsonPath = episodeDirPath.resolve("transcript.json")
         if (Files.exists(jsonPath)) return
-        if (vtt.isBlank()) return
+        if (vtt.isBlank()) {
+            logger.warn("Transcription for ${entry.title} came back empty; not writing transcript.json")
+            return
+        }
 
         val episodeDict =
             buildEpisodeDict(feed, entry, vtt, mp3Info.localFilePath, collections)
@@ -201,35 +207,15 @@ class PodcastPipeline(
             episodePath: Path,
             dataDir: String,
         ): Mp3Info? {
-            for (enclosure in entry.enclosures) {
-                if (enclosure.type in AUDIO_MP3_TYPES) {
-                    val filePath = episodePath.resolve("audio.mp3")
-                    val relativePath = Path.of(dataDir).relativize(filePath).toString()
+            val source = findAudioSource(entry) ?: return null
+            val filePath = episodePath.resolve("audio.mp3")
 
-                    return Mp3Info(
-                        url = enclosure.url,
-                        filePath = filePath,
-                        length = enclosure.length,
-                        localFilePath = relativePath,
-                    )
-                }
-            }
-
-            for (link in entry.links) {
-                if (link.type in AUDIO_MP3_TYPES) {
-                    val filePath = episodePath.resolve("audio.mp3")
-                    val relativePath = Path.of(dataDir).relativize(filePath).toString()
-
-                    return Mp3Info(
-                        url = link.href,
-                        filePath = filePath,
-                        length = link.length,
-                        localFilePath = relativePath,
-                    )
-                }
-            }
-
-            return null
+            return Mp3Info(
+                url = source.url,
+                filePath = filePath,
+                length = source.length,
+                localFilePath = Path.of(dataDir).relativize(filePath).toString(),
+            )
         }
 
         fun buildEpisodeDict(
@@ -292,13 +278,23 @@ class PodcastPipeline(
             }
         }
 
-        private fun findAudioLink(entry: SyndEntry): String? =
+        private data class AudioSource(val url: String, val length: Long)
+
+        // Single source of truth for locating an episode's audio: mp3 enclosure
+        // first, then a link that is either mp3-typed or rel="enclosure". Keeping
+        // one predicate means findAudioLink and getMp3Info can never disagree
+        // about whether an episode has audio.
+        private fun findAudioSource(entry: SyndEntry): AudioSource? {
             entry.enclosures
                 .firstOrNull { it.type in AUDIO_MP3_TYPES }
-                ?.url
-                ?: entry.links
-                    .firstOrNull { it.rel == "enclosure" }
-                    ?.href
+                ?.let { return AudioSource(it.url, it.length) }
+
+            return entry.links
+                .firstOrNull { it.type in AUDIO_MP3_TYPES || it.rel == "enclosure" }
+                ?.let { AudioSource(it.href, it.length) }
+        }
+
+        private fun findAudioLink(entry: SyndEntry): String? = findAudioSource(entry)?.url
 
         private fun collectTags(
             feed: SyndFeed,

--- a/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
@@ -127,6 +127,45 @@ class AppConfigTest {
     }
 
     @Test
+    fun `load keeps yaml verbose when env var is absent`(
+        @TempDir tmp: Path,
+    ) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("verbose: true\n")
+
+        val config =
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                ),
+            )
+
+        assertEquals(true, config.verbose)
+    }
+
+    @Test
+    fun `load lets env verbose override yaml verbose`(
+        @TempDir tmp: Path,
+    ) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("verbose: true\n")
+
+        val config =
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                    "PIPELINE_VERBOSE" to "false",
+                ),
+            )
+
+        assertEquals(false, config.verbose)
+    }
+
+    @Test
     fun `load errors when PIPELINE_CONFIG_PATH is missing`() {
         val ex =
             assertFailsWith<IllegalStateException> {

--- a/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
@@ -166,6 +166,26 @@ class AppConfigTest {
     }
 
     @Test
+    fun `load keeps yaml verbose when env var is blank`(
+        @TempDir tmp: Path,
+    ) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("verbose: true\n")
+
+        val config =
+            AppConfig.load(
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                    "PIPELINE_VERBOSE" to "",
+                ),
+            )
+
+        assertEquals(true, config.verbose)
+    }
+
+    @Test
     fun `load errors when PIPELINE_CONFIG_PATH is missing`() {
         val ex =
             assertFailsWith<IllegalStateException> {

--- a/pipeline/src/test/kotlin/com/rsstowhisper/feed/FeedServiceTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/feed/FeedServiceTest.kt
@@ -104,15 +104,46 @@ class FeedServiceTest {
     }
 
     @Test
-    fun `downloadAudio writes body to target path`(
+    fun `downloadAudio writes body to target path and returns true`(
         @TempDir tmp: Path,
     ) {
         val target = tmp.resolve("episode.mp3")
-        FeedService(clientReturning(body = "audio-bytes")).downloadAudio("https://example.com/ep.mp3", target)
+        val ok = FeedService(clientReturning(body = "audio-bytes")).downloadAudio("https://example.com/ep.mp3", target)
 
+        assertTrue(ok)
         assertTrue(Files.exists(target))
         assertEquals("audio-bytes", Files.readString(target))
         assertTrue(Files.notExists(tmp.resolve("episode.mp3.part")))
+    }
+
+    @Test
+    fun `downloadAudio returns true without a request when file already present`(
+        @TempDir tmp: Path,
+    ) {
+        val target = tmp.resolve("episode.mp3")
+        Files.writeString(target, "existing")
+
+        assertTrue(FeedService(clientReturning(responseCode = 500)).downloadAudio("https://example.com/ep.mp3", target))
+    }
+
+    @Test
+    fun `downloadAudio returns false on non-200 response`(
+        @TempDir tmp: Path,
+    ) {
+        val target = tmp.resolve("episode.mp3")
+        val ok = FeedService(clientReturning(responseCode = 503)).downloadAudio("https://example.com/ep.mp3", target)
+        assertEquals(false, ok)
+    }
+
+    @Test
+    fun `downloadAudio returns false on network exception`(
+        @TempDir tmp: Path,
+    ) {
+        val target = tmp.resolve("episode.mp3")
+        val ok =
+            FeedService(clientThrowing(IOException("connection reset")))
+                .downloadAudio("https://example.com/ep.mp3", target)
+        assertEquals(false, ok)
     }
 
     /**

--- a/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineCompanionTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineCompanionTest.kt
@@ -219,6 +219,30 @@ class PodcastPipelineCompanionTest {
     }
 
     @Test
+    fun `getMp3Info ignores a typed non-audio enclosure link`() {
+        // A link that declares itself video is not audio. Downloading it as
+        // audio.mp3 would park an undecodable file on disk, and its presence
+        // marks the download as done, so every later run would re-transcribe it.
+        val e = entry(links = listOf(link("https://cdn/ep.mp4", type = "video/mp4", rel = "enclosure")))
+        assertNull(PodcastPipeline.getMp3Info(e, Path.of("/data/show/ep"), "/data"))
+    }
+
+    @Test
+    fun `getMp3Info prefers an mp3 link over an earlier untyped enclosure link`() {
+        val e =
+            entry(
+                links =
+                    listOf(
+                        link("https://cdn/notes.html", rel = "enclosure"),
+                        link("https://cdn/ep.mp3", type = "audio/mpeg", length = 99L),
+                    ),
+            )
+        val result = PodcastPipeline.getMp3Info(e, Path.of("/data/show/ep"), "/data")
+        assertEquals("https://cdn/ep.mp3", result?.url)
+        assertEquals(99L, result?.length)
+    }
+
+    @Test
     fun `getMp3Info prefers enclosure over link when both match`() {
         val e =
             entry(

--- a/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineCompanionTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineCompanionTest.kt
@@ -209,6 +209,16 @@ class PodcastPipelineCompanionTest {
     }
 
     @Test
+    fun `getMp3Info falls back to rel enclosure link with no type`() {
+        // Same fallback buildEpisodeDict uses — the two must agree, or the
+        // pipeline downloads an episode it then refuses to write json for.
+        val e = entry(links = listOf(link("https://cdn/ep.mp3", rel = "enclosure", length = 42L)))
+        val result = PodcastPipeline.getMp3Info(e, Path.of("/data/show/ep"), "/data")
+        assertEquals("https://cdn/ep.mp3", result?.url)
+        assertEquals(42L, result?.length)
+    }
+
+    @Test
     fun `getMp3Info prefers enclosure over link when both match`() {
         val e =
             entry(

--- a/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineRunTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineRunTest.kt
@@ -23,7 +23,7 @@ private const val FAKE_SERVER_URL = "http://localhost:9000"
 private val MINIMAL_VTT = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n Hello world.\n"
 
 class PodcastPipelineRunTest {
-    private class FakeFeedService(private val feeds: Map<String, SyndFeed?>) : FeedService() {
+    private open class FakeFeedService(private val feeds: Map<String, SyndFeed?>) : FeedService() {
         val requestedUrls = mutableListOf<String>()
         val downloads = mutableListOf<Pair<String, Path>>()
 
@@ -35,12 +35,13 @@ class PodcastPipelineRunTest {
         override fun downloadAudio(
             url: String,
             targetPath: Path,
-        ) {
+        ): Boolean {
             // Mirrors the real skip-if-present contract, so tests can assert on it.
-            if (Files.exists(targetPath)) return
+            if (Files.exists(targetPath)) return true
             downloads.add(url to targetPath)
             Files.createDirectories(targetPath.parent)
             Files.writeString(targetPath, "fake-mp3-bytes")
+            return true
         }
     }
 
@@ -292,6 +293,31 @@ class PodcastPipelineRunTest {
         assertEquals(0, txSvc.calls.size)
         val fourthDir = podcastDir.resolve(escapeFilename(PodcastPipeline.getEpisodeDirName(e4)))
         assertFalse(Files.exists(fourthDir))
+    }
+
+    @Test
+    fun `run does not transcribe an episode whose download failed`(
+        @TempDir tempDir: Path,
+    ) {
+        val config =
+            AppConfig(
+                dataDirectory = tempDir.toAbsolutePath().toString(),
+                whisperServerUrl = FAKE_SERVER_URL,
+                podcasts = listOf(PodcastConfig(name = "Show", url = "https://feed")),
+            )
+        val feedSvc =
+            object : FakeFeedService(mapOf("https://feed" to makeFeed(makeEntry("Unfetchable")))) {
+                override fun downloadAudio(
+                    url: String,
+                    targetPath: Path,
+                ): Boolean = false
+            }
+        val txSvc = FakeTranscriber(FAKE_SERVER_URL, MINIMAL_VTT)
+        PodcastPipeline(config = config, feedService = feedSvc, transcriber = txSvc).run()
+
+        assertEquals(0, txSvc.calls.size)
+        val episodeDirs = Files.list(tempDir.resolve("Show")).use { it.toList() }
+        assertFalse(episodeDirs.any { Files.exists(it.resolve("transcript.json")) })
     }
 
     @Test

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     // SQLite JDBC — not in Quarkus BOM; used directly without Agroal
     implementation("org.xerial:sqlite-jdbc:3.49.1.0")
 
+    // Episode summaries are third-party RSS content rendered as raw HTML, so
+    // they are sanitised against an allow-list before reaching the template.
+    implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1")
+
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.mockk:mockk:1.13.12")
 }

--- a/web/src/main/kotlin/com/rsstowhisper/web/SearchResource.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/SearchResource.kt
@@ -6,6 +6,7 @@ import com.rsstowhisper.web.models.buildSearchUrl
 import com.rsstowhisper.web.models.hasActiveFilters
 import com.rsstowhisper.web.models.linkify
 import com.rsstowhisper.web.models.parseTranscript
+import com.rsstowhisper.web.models.sanitizeHtml
 import io.smallrye.common.annotation.Blocking
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -105,7 +106,7 @@ class SearchResource {
         val transcriptLines = episode.transcript?.let { parseTranscript(it) } ?: emptyList()
         val linkifiedSummary =
             episode.episodeSummary?.let {
-                if (it.contains('<')) it else linkify(it)
+                if (it.contains('<')) sanitizeHtml(it) else linkify(it)
             }
 
         val ctx =

--- a/web/src/main/kotlin/com/rsstowhisper/web/db/EpisodeRepository.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/db/EpisodeRepository.kt
@@ -190,22 +190,32 @@ class EpisodeRepository {
     // FTS5 MATCH parses its right-hand side as a query language, so raw user
     // input like `c++` or an unbalanced quote raises a SQLException that would
     // surface as a 500. Valid queries pass through untouched (keeping phrase
-    // and boolean operators working); anything FTS5 rejects is retried with
-    // each token quoted as a literal. Returns null for blank input.
+    // and boolean operators working); anything FTS5 rejects is rewritten with
+    // each token quoted as a literal. Returns null only for blank input.
     private fun safeFtsQuery(query: String): String? {
         if (query.isBlank()) return null
         if (isValidFtsQuery(query)) return query
 
-        val quoted =
-            query
-                .split(Regex("\\s+"))
-                .filter { it.isNotBlank() }
-                .joinToString(" ") { "\"${it.replace("\"", "\"\"")}\"" }
-        return quoted.takeIf { it.isNotBlank() && isValidFtsQuery(it) }
+        // The quoted form is a sequence of FTS5 string literals, so it is always
+        // syntactically valid -- it is returned without a second probe on purpose.
+        // A probe that failed for some reason other than the user's syntax (no
+        // episodes_fts table mid-reindex, a locked or corrupt database) must not
+        // be able to turn into a null here: that would drop the search term and
+        // hand the caller the entire corpus as if it had matched. Letting the
+        // real query raise the underlying error is the honest outcome.
+        return quoteEachToken(query)
     }
+
+    private fun quoteEachToken(query: String): String =
+        query
+            .split(Regex("\\s+"))
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { "\"${it.replace("\"", "\"\"")}\"" }
 
     // LIMIT 1 rather than LIMIT 0: FTS5 only parses the MATCH expression when
     // the statement is actually stepped, and LIMIT 0 short-circuits the step.
+    // A failure here only decides whether to quote; it is never treated as
+    // "this search matched nothing".
     private fun isValidFtsQuery(query: String): Boolean =
         runCatching {
             conn.prepareStatement("SELECT 1 FROM episodes_fts WHERE episodes_fts MATCH ? LIMIT 1").use { stmt ->

--- a/web/src/main/kotlin/com/rsstowhisper/web/db/EpisodeRepository.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/db/EpisodeRepository.kt
@@ -82,7 +82,10 @@ class EpisodeRepository {
         // column_index -1 = search across all columns
         val snippetExpr =
             if (hasQuery) {
-                "snippet(episodes_fts, -1, '<mark>', '</mark>', '…', 40)"
+                // char(1)/char(2) rather than literal <mark> tags: the snippet
+                // is escaped before rendering, so highlight markers must be
+                // something feed text cannot contain. See Episode.snippetHtml.
+                "snippet(episodes_fts, -1, char(1), char(2), '…', 40)"
             } else {
                 "NULL"
             }

--- a/web/src/main/kotlin/com/rsstowhisper/web/db/EpisodeRepository.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/db/EpisodeRepository.kt
@@ -20,11 +20,13 @@ class EpisodeRepository {
 
     private lateinit var conn: Connection
 
-    // In-memory filter cache — single entry, keyed by query string.
-    // Access is serialised by the @Synchronized methods below, so no
-    // additional locking is needed.
+    // In-memory filter cache — single entry, keyed by query string, expiring
+    // after a short TTL so an external reindex by index.py shows up without a
+    // server restart. Access is serialised by the @Synchronized methods below,
+    // so no additional locking is needed.
     private var cachedFilterQuery: String? = null
     private var cachedFilterOptions: FilterOptions? = null
+    private var cachedFilterAtMillis: Long = 0
 
     @PostConstruct
     fun init() {
@@ -42,19 +44,20 @@ class EpisodeRepository {
 
     @Synchronized
     fun search(filters: SearchFilters): SearchResult {
-        val hasQuery = filters.query.isNotBlank()
+        val ftsQuery = safeFtsQuery(filters.query)
+        val hasQuery = ftsQuery != null
         val params = mutableListOf<Any>()
         val whereClauses = mutableListOf<String>()
 
-        if (hasQuery) {
+        if (ftsQuery != null) {
             whereClauses.add("episodes_fts MATCH ?")
-            params.add(filters.query)
+            params.add(ftsQuery)
         }
 
         addDurationFilter(filters, whereClauses, params)
         addSetFilter(filters.podcasts, "e.podcast_title", whereClauses, params)
-        addCollectionsFilter(filters.collections, whereClauses, params)
-        addTagsFilter(filters.tags, whereClauses, params)
+        addCsvContainsFilter(filters.collections, "e.podcast_collections", whereClauses, params)
+        addCsvContainsFilter(filters.tags, "e.all_tags", whereClauses, params)
         addSetFilter(filters.episodeTypes, "e.episode_type", whereClauses, params)
 
         val whereClause = if (whereClauses.isEmpty()) "" else "WHERE ${whereClauses.joinToString(" AND ")}"
@@ -130,9 +133,13 @@ class EpisodeRepository {
 
     @Synchronized
     fun getFilterOptions(query: String): FilterOptions {
-        if (query == cachedFilterQuery) return cachedFilterOptions!!
+        val now = System.currentTimeMillis()
+        if (query == cachedFilterQuery && now - cachedFilterAtMillis < FILTER_CACHE_TTL_MILLIS) {
+            return cachedFilterOptions!!
+        }
 
-        val hasQuery = query.isNotBlank()
+        val ftsQuery = safeFtsQuery(query)
+        val hasQuery = ftsQuery != null
         val fromClause =
             if (hasQuery) {
                 "FROM episodes e JOIN episodes_fts ON e.rowid = episodes_fts.rowid"
@@ -144,7 +151,7 @@ class EpisodeRepository {
         fun queryDistinct(column: String): List<String> {
             val sql = "SELECT DISTINCT $column $fromClause $wherePrefix $column IS NOT NULL ORDER BY $column"
             return conn.prepareStatement(sql).use { stmt ->
-                if (hasQuery) stmt.setString(1, query)
+                if (ftsQuery != null) stmt.setString(1, ftsQuery)
                 stmt.executeQuery().use { rs ->
                     generateSequence { if (rs.next()) rs.getString(1) else null }.toList()
                 }
@@ -154,7 +161,7 @@ class EpisodeRepository {
         fun splitCsv(column: String): List<String> {
             val sql = "SELECT DISTINCT $column $fromClause $wherePrefix $column IS NOT NULL"
             return conn.prepareStatement(sql).use { stmt ->
-                if (hasQuery) stmt.setString(1, query)
+                if (ftsQuery != null) stmt.setString(1, ftsQuery)
                 stmt.executeQuery().use { rs ->
                     generateSequence { if (rs.next()) rs.getString(1) else null }
                         .flatMap { it.split(",").map(String::trim) }
@@ -173,8 +180,36 @@ class EpisodeRepository {
             )
         cachedFilterQuery = query
         cachedFilterOptions = options
+        cachedFilterAtMillis = now
         return options
     }
+
+    // FTS5 MATCH parses its right-hand side as a query language, so raw user
+    // input like `c++` or an unbalanced quote raises a SQLException that would
+    // surface as a 500. Valid queries pass through untouched (keeping phrase
+    // and boolean operators working); anything FTS5 rejects is retried with
+    // each token quoted as a literal. Returns null for blank input.
+    private fun safeFtsQuery(query: String): String? {
+        if (query.isBlank()) return null
+        if (isValidFtsQuery(query)) return query
+
+        val quoted =
+            query
+                .split(Regex("\\s+"))
+                .filter { it.isNotBlank() }
+                .joinToString(" ") { "\"${it.replace("\"", "\"\"")}\"" }
+        return quoted.takeIf { it.isNotBlank() && isValidFtsQuery(it) }
+    }
+
+    // LIMIT 1 rather than LIMIT 0: FTS5 only parses the MATCH expression when
+    // the statement is actually stepped, and LIMIT 0 short-circuits the step.
+    private fun isValidFtsQuery(query: String): Boolean =
+        runCatching {
+            conn.prepareStatement("SELECT 1 FROM episodes_fts WHERE episodes_fts MATCH ? LIMIT 1").use { stmt ->
+                stmt.setString(1, query)
+                stmt.executeQuery().use { it.next() }
+            }
+        }.isSuccess
 
     private fun addDurationFilter(
         filters: SearchFilters,
@@ -207,26 +242,19 @@ class EpisodeRepository {
         params.addAll(values)
     }
 
-    private fun addCollectionsFilter(
+    // Exact element match against a ", "-separated column. Wrapping both sides
+    // in commas stops 'art' matching 'smart', and instr (unlike LIKE) treats
+    // '%' and '_' in the value as literals.
+    private fun addCsvContainsFilter(
         values: Set<String>,
+        column: String,
         clauses: MutableList<String>,
         params: MutableList<Any>,
     ) {
         if (values.isEmpty()) return
-        val conditions = values.map { "e.podcast_collections LIKE ?" }
-        clauses.add("(${conditions.joinToString(" OR ")})")
-        values.forEach { params.add("%$it%") }
-    }
-
-    private fun addTagsFilter(
-        values: Set<String>,
-        clauses: MutableList<String>,
-        params: MutableList<Any>,
-    ) {
-        if (values.isEmpty()) return
-        val conditions = values.map { "e.all_tags LIKE ?" }
-        clauses.add("(${conditions.joinToString(" OR ")})")
-        values.forEach { params.add("%$it%") }
+        val condition = "instr(',' || REPLACE(lower($column), ', ', ',') || ',', lower(?)) > 0"
+        clauses.add("(${values.joinToString(" OR ") { condition }})")
+        values.forEach { params.add(",${it.trim()},") }
     }
 
     private fun setParam(
@@ -267,6 +295,8 @@ class EpisodeRepository {
         )
 
     companion object {
+        private const val FILTER_CACHE_TTL_MILLIS = 60_000L
+
         private const val SEARCH_COLUMNS =
             """e.id, e.podcast_title, e.podcast_image, e.podcast_collections,
                e.episode_title, e.episode_published_on, e.episode_audio_link,

--- a/web/src/main/kotlin/com/rsstowhisper/web/models/SearchModels.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/models/SearchModels.kt
@@ -1,5 +1,8 @@
 package com.rsstowhisper.web.models
 
+import org.owasp.html.PolicyFactory
+import org.owasp.html.Sanitizers
+
 data class Episode(
     val id: String,
     val podcastTitle: String?,
@@ -29,6 +32,12 @@ data class Episode(
             ?.filter(String::isNotBlank)
             ?: emptyList()
     val audioPath: String? get() = episodeRelativeAudioPath
+
+    // The raw snippet is feed-controlled text (it spans episode_title and
+    // podcast_title as well as the transcript) with sentinel highlight markers.
+    // Escape it, then turn only the sentinels into <mark> -- so a feed cannot
+    // smuggle markup through by containing a literal "<mark>".
+    val snippetHtml: String? get() = snippet?.let { renderSnippet(it) }
 }
 
 data class SearchResult(
@@ -155,6 +164,26 @@ fun parseTranscript(transcript: String): List<TranscriptLine> {
     flush()
     return result
 }
+
+// Sentinel code points wrapped around FTS5 matches by EpisodeRepository. They
+// cannot occur in feed or transcript text, so they survive HTML escaping
+// unambiguously and mark exactly what the search engine matched.
+const val SNIPPET_MARK_START = "\u0001"
+const val SNIPPET_MARK_END = "\u0002"
+
+fun renderSnippet(snippet: String): String =
+    escapeHtml(snippet)
+        .replace(SNIPPET_MARK_START, "<mark>")
+        .replace(SNIPPET_MARK_END, "</mark>")
+
+// Episode summaries arrive as raw HTML from third-party feeds. Anything outside
+// this allow-list (script, iframe, event handlers, javascript: URLs) is dropped.
+private val SUMMARY_POLICY: PolicyFactory =
+    Sanitizers.FORMATTING
+        .and(Sanitizers.BLOCKS)
+        .and(Sanitizers.LINKS)
+
+fun sanitizeHtml(html: String): String = SUMMARY_POLICY.sanitize(html)
 
 private val URL_REGEX = Regex("""https?://[^\s<>"]+""")
 

--- a/web/src/main/kotlin/com/rsstowhisper/web/models/SearchModels.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/models/SearchModels.kt
@@ -178,9 +178,12 @@ fun renderSnippet(snippet: String): String =
 
 // Episode summaries arrive as raw HTML from third-party feeds. Anything outside
 // this allow-list (script, iframe, event handlers, javascript: URLs) is dropped.
+// IMAGES is included because show notes routinely embed artwork; it permits
+// <img> only with an http/https src, and no event handlers survive it.
 private val SUMMARY_POLICY: PolicyFactory =
     Sanitizers.FORMATTING
         .and(Sanitizers.BLOCKS)
+        .and(Sanitizers.IMAGES)
         .and(Sanitizers.LINKS)
 
 fun sanitizeHtml(html: String): String = SUMMARY_POLICY.sanitize(html)

--- a/web/src/main/kotlin/com/rsstowhisper/web/models/SearchModels.kt
+++ b/web/src/main/kotlin/com/rsstowhisper/web/models/SearchModels.kt
@@ -77,14 +77,20 @@ fun SearchFilters.hasActiveFilters(): Boolean =
     query.isNotBlank() || durations.isNotEmpty() || podcasts.isNotEmpty() ||
         collections.isNotEmpty() || tags.isNotEmpty() || episodeTypes.isNotEmpty()
 
+// URLEncoder targets form encoding, where a space becomes '+'. Whether '+' is
+// decoded back to a space in a *query string* is up to the server, so spaces are
+// re-written as %20, which every decoder agrees on. Any '+' left after encoding
+// is an encoded space -- a literal '+' in the input has already become %2B.
+private fun urlEncode(value: String): String = java.net.URLEncoder.encode(value, Charsets.UTF_8).replace("+", "%20")
+
 fun buildSearchUrl(filters: SearchFilters): String {
     val params = mutableListOf<String>()
-    if (filters.query.isNotBlank()) params.add("q=${filters.query}")
-    filters.durations.forEach { params.add("duration=$it") }
-    filters.podcasts.forEach { params.add("podcast=$it") }
-    filters.collections.forEach { params.add("collection=$it") }
-    filters.tags.forEach { params.add("tag=$it") }
-    filters.episodeTypes.forEach { params.add("episodeType=$it") }
+    if (filters.query.isNotBlank()) params.add("q=${urlEncode(filters.query)}")
+    filters.durations.forEach { params.add("duration=${urlEncode(it)}") }
+    filters.podcasts.forEach { params.add("podcast=${urlEncode(it)}") }
+    filters.collections.forEach { params.add("collection=${urlEncode(it)}") }
+    filters.tags.forEach { params.add("tag=${urlEncode(it)}") }
+    filters.episodeTypes.forEach { params.add("episodeType=${urlEncode(it)}") }
     if (filters.page > 1) params.add("page=${filters.page}")
     return "/search?${params.joinToString("&")}"
 }

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Path to the SQLite database produced by index.py
 app.db.path=${APP_DB_PATH:/podcasts.db}
 
-# Base URL prefix for WAV audio files served externally (no trailing slash)
+# Base URL prefix for the MP3 audio files served externally (no trailing slash)
 app.audio.base-url=${APP_AUDIO_BASE_URL:/audio}
 
 # Thymeleaf template caching — disabled in dev so live-reload picks up edits

--- a/web/src/main/resources/templates/search.html
+++ b/web/src/main/resources/templates/search.html
@@ -202,10 +202,11 @@
                           th:text="${episode.episodeType}"></span>
                 </div>
 
-                <!-- Snippet: use th:utext because it contains <mark> highlight tags -->
+                <!-- Snippet: th:utext is safe here because snippetHtml is HTML-escaped
+                     and only re-introduces the <mark> tags. -->
                 <div class="snippet"
-                     th:if="${episode.snippet != null}"
-                     th:utext="${episode.snippet}"></div>
+                     th:if="${episode.snippetHtml != null}"
+                     th:utext="${episode.snippetHtml}"></div>
 
                 <!-- Tags -->
                 <div th:if="${not episode.tagList.isEmpty()}">

--- a/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 
 class EpisodeRepositoryTest {
     @TempDir
@@ -227,6 +229,20 @@ class EpisodeRepositoryTest {
         }
 
         @Test
+        fun `an unmatchable query returns no results rather than the whole corpus`() {
+            // safeFtsQuery must never degrade a non-blank query to "no query":
+            // that path silently hands back every episode as if it had matched.
+            val total = repo.search(SearchFilters()).totalCount
+            assertTrue(total > 0, "fixture should have episodes")
+            for (q in listOf("c++", "\"unbalanced", "AND", "kotlin AND", "(open", "*star", "-", "^")) {
+                assertTrue(
+                    repo.search(SearchFilters(query = q)).totalCount < total,
+                    "query '$q' fell back to returning the entire corpus",
+                )
+            }
+        }
+
+        @Test
         fun `getFilterOptions with FTS syntax characters does not throw`() {
             // Falls back to a quoted literal, which matches nothing in the fixtures.
             val options = repo.getFilterOptions("\"unbalanced")
@@ -366,6 +382,31 @@ class EpisodeRepositoryTest {
                 val result = repo.search(SearchFilters(page = 99, pageSize = 10))
                 assertTrue(result.episodes.isEmpty())
                 assertEquals(4, result.totalCount)
+            }
+        }
+    }
+
+    @Nested
+    inner class BrokenFtsTable {
+        // index.py drops episodes_fts at the start of a reindex and only
+        // recreates it at the end, so the web server can meet a database whose
+        // episodes table is populated but whose FTS index is gone. A search must
+        // fail loudly there rather than quietly dropping the term and handing
+        // back every episode as if it had matched.
+        @Test
+        fun `a search against a missing episodes_fts raises instead of returning everything`() {
+            val dbPath = tempDir.resolve("no-fts.db").toAbsolutePath().toString()
+            DriverManager.getConnection("jdbc:sqlite:$dbPath").use { conn ->
+                createSchema(conn)
+                insertFixtures(conn)
+                conn.createStatement().execute("DROP TABLE episodes_fts")
+            }
+            val brokenRepo = EpisodeRepository().apply { this.dbPath = dbPath }
+            brokenRepo.init()
+            try {
+                assertThrows(SQLException::class.java) { brokenRepo.search(SearchFilters(query = "kotlin")) }
+            } finally {
+                brokenRepo.cleanup()
             }
         }
     }

--- a/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
@@ -152,7 +152,7 @@ class EpisodeRepositoryTest {
             stmt.setObject(8, type)
             stmt.setString(9, "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n$transcriptPlain\n")
             stmt.setString(10, transcriptPlain)
-            stmt.setString(11, "$id/audio.wav")
+            stmt.setString(11, "$id/audio.mp3")
             stmt.execute()
         }
     }

--- a/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
@@ -1,6 +1,9 @@
 package com.rsstowhisper.web.db
 
+import com.rsstowhisper.web.models.SNIPPET_MARK_END
+import com.rsstowhisper.web.models.SNIPPET_MARK_START
 import com.rsstowhisper.web.models.SearchFilters
+import com.rsstowhisper.web.models.renderSnippet
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -171,6 +174,17 @@ class EpisodeRepositoryTest {
             assertEquals(1, result.totalCount)
             assertEquals("ep1", result.episodes.single().id)
             assertNotNull(result.episodes.single().snippet)
+        }
+
+        @Test
+        fun `snippet highlights with sentinels, not literal mark tags`() {
+            // Pins the contract with Episode.snippetHtml: the repository emits
+            // char(1)/char(2) so the snippet can be HTML-escaped before render.
+            val snippet = repo.search(SearchFilters(query = "kotlin")).episodes.single().snippet!!
+            assertTrue(snippet.contains(SNIPPET_MARK_START), "expected start sentinel in: $snippet")
+            assertTrue(snippet.contains(SNIPPET_MARK_END), "expected end sentinel in: $snippet")
+            assertFalse(snippet.contains("<mark>"))
+            assertTrue(renderSnippet(snippet).contains("<mark>"))
         }
 
         @Test

--- a/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/db/EpisodeRepositoryTest.kt
@@ -187,6 +187,38 @@ class EpisodeRepositoryTest {
             assertTrue(repo.search(SearchFilters()).episodes.all { it.snippet == null })
         }
 
+        @Test
+        fun `query with FTS syntax characters does not throw`() {
+            // Each of these is invalid FTS5 syntax as-is; raw MATCH would raise
+            // a SQLException that surfaced to the user as a 500.
+            for (q in listOf("c++", "\"unbalanced", "AND", "kotlin AND", "(open", "*star")) {
+                val result = repo.search(SearchFilters(query = q))
+                assertTrue(result.totalCount >= 0, "query '$q' should not throw")
+            }
+        }
+
+        @Test
+        fun `quoted fallback still finds matching terms`() {
+            // 'kotlin++' is invalid FTS5; the fallback quotes it as a literal
+            // token, which FTS tokenises back to 'kotlin' and matches ep1.
+            val result = repo.search(SearchFilters(query = "kotlin++"))
+            assertEquals(1, result.totalCount)
+            assertEquals("ep1", result.episodes.single().id)
+        }
+
+        @Test
+        fun `valid boolean queries keep working`() {
+            val result = repo.search(SearchFilters(query = "kotlin OR java"))
+            assertEquals(2, result.totalCount)
+        }
+
+        @Test
+        fun `getFilterOptions with FTS syntax characters does not throw`() {
+            // Falls back to a quoted literal, which matches nothing in the fixtures.
+            val options = repo.getFilterOptions("\"unbalanced")
+            assertTrue(options.podcasts.isEmpty())
+        }
+
         @Nested
         inner class DurationFilter {
             @Test
@@ -254,6 +286,17 @@ class EpisodeRepositoryTest {
                 assertTrue("ep1" in ids)
                 assertTrue("ep3" in ids)
             }
+
+            @Test
+            fun `collections filter does not match on substring`() {
+                // 'sci' is a prefix of 'science'; the old LIKE %sci% matched it.
+                assertEquals(0, repo.search(SearchFilters(collections = setOf("sci"))).totalCount)
+            }
+
+            @Test
+            fun `collections filter is case-insensitive`() {
+                assertEquals(2, repo.search(SearchFilters(collections = setOf("Science"))).totalCount)
+            }
         }
 
         @Nested
@@ -263,6 +306,17 @@ class EpisodeRepositoryTest {
                 val result = repo.search(SearchFilters(tags = setOf("kotlin")))
                 assertEquals(1, result.totalCount)
                 assertEquals("ep1", result.episodes.single().id)
+            }
+
+            @Test
+            fun `tags filter does not match on substring`() {
+                // 'ava' is inside 'java'; the old LIKE %ava% matched it.
+                assertEquals(0, repo.search(SearchFilters(tags = setOf("ava"))).totalCount)
+            }
+
+            @Test
+            fun `tags filter treats percent as a literal`() {
+                assertEquals(0, repo.search(SearchFilters(tags = setOf("%"))).totalCount)
             }
         }
 

--- a/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
@@ -216,6 +216,23 @@ class SearchModelsTest {
             assertTrue(url.contains("duration=SHORT"))
             assertTrue(url.contains("page=2"))
         }
+
+        @Test
+        fun `values are URL-encoded`() {
+            val url = buildSearchUrl(SearchFilters(query = "c++ & more", podcasts = setOf("My Podcast")))
+            assertTrue(url.contains("q=c%2B%2B%20%26%20more"))
+            assertTrue(url.contains("podcast=My%20Podcast"))
+            assertFalse(url.contains("My Podcast"))
+            // Spaces must not round-trip as '+', whose meaning in a query
+            // string is server-dependent.
+            assertFalse(url.contains("+"))
+        }
+
+        @Test
+        fun `ampersand in a filter value cannot split parameters`() {
+            val url = buildSearchUrl(SearchFilters(tags = setOf("rock&roll")))
+            assertTrue(url.contains("tag=rock%26roll"))
+        }
     }
 
     @Nested

--- a/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
@@ -213,6 +213,13 @@ class SearchModelsTest {
         }
 
         @Test
+        fun `sanitizeHtml keeps http images but not their handlers`() {
+            val clean = sanitizeHtml("""<p><img src="https://cdn.example/art.jpg" onerror="alert(1)"/>Notes</p>""")
+            assertTrue(clean.contains("https://cdn.example/art.jpg"))
+            assertFalse(clean.contains("onerror", ignoreCase = true))
+        }
+
+        @Test
         fun `renderSnippet escapes markup and converts sentinels to mark`() {
             val raw = "before ${SNIPPET_MARK_START}hit${SNIPPET_MARK_END} <script>alert(1)</script>"
             val html = renderSnippet(raw)

--- a/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
+++ b/web/src/test/kotlin/com/rsstowhisper/web/models/SearchModelsTest.kt
@@ -189,6 +189,48 @@ class SearchModelsTest {
     }
 
     @Nested
+    inner class HtmlSafety {
+        @Test
+        fun `sanitizeHtml strips script tags and event handlers`() {
+            val dirty = "<p>Hi</p><script>alert(1)</script><img src=x onerror=alert(2)>"
+            val clean = sanitizeHtml(dirty)
+            assertFalse(clean.contains("script", ignoreCase = true))
+            assertFalse(clean.contains("onerror", ignoreCase = true))
+            assertTrue(clean.contains("Hi"))
+        }
+
+        @Test
+        fun `sanitizeHtml drops javascript URLs but keeps safe links`() {
+            assertFalse(sanitizeHtml("""<a href="javascript:alert(1)">x</a>""").contains("javascript"))
+            assertTrue(sanitizeHtml("""<a href="https://ok.example/">x</a>""").contains("https://ok.example/"))
+        }
+
+        @Test
+        fun `sanitizeHtml keeps ordinary summary formatting`() {
+            val clean = sanitizeHtml("<p>Episode <b>notes</b> and <em>more</em></p>")
+            assertTrue(clean.contains("<b>notes</b>"))
+            assertTrue(clean.contains("<em>more</em>"))
+        }
+
+        @Test
+        fun `renderSnippet escapes markup and converts sentinels to mark`() {
+            val raw = "before ${SNIPPET_MARK_START}hit${SNIPPET_MARK_END} <script>alert(1)</script>"
+            val html = renderSnippet(raw)
+            assertTrue(html.contains("<mark>hit</mark>"))
+            assertFalse(html.contains("<script>"))
+            assertTrue(html.contains("&lt;script&gt;"))
+        }
+
+        @Test
+        fun `renderSnippet does not honour a literal mark tag from feed text`() {
+            // A feed that puts "<mark>" in its title must not get real markup out.
+            val html = renderSnippet("a <mark>fake</mark> highlight")
+            assertFalse(html.contains("<mark>"))
+            assertTrue(html.contains("&lt;mark&gt;"))
+        }
+    }
+
+    @Nested
     inner class BuildSearchUrl {
         @Test
         fun `empty filters produces base URL with no params`() = assertEquals("/search?", buildSearchUrl(SearchFilters()))
@@ -308,6 +350,16 @@ class SearchModelsTest {
 
         @Test
         fun `formattedDuration formats duration correctly`() = assertEquals("1h 0m", episode(duration = 3600).formattedDuration)
+
+        @Test
+        fun `snippetHtml is null when there is no snippet`() = assertNull(episode().snippetHtml)
+
+        @Test
+        fun `snippetHtml renders sentinels as mark tags`() =
+            assertEquals(
+                "a <mark>b</mark> c",
+                episode(snippet = "a ${SNIPPET_MARK_START}b${SNIPPET_MARK_END} c").snippetHtml,
+            )
 
         @Test
         fun `tagList is empty when allTags is null`() = assertTrue(episode().tagList.isEmpty())


### PR DESCRIPTION
An outsider review of the repo (produced against `8158ba8`) flagged a set of
bugs across all three components. Every claim was checked against the code
before anything was applied, and the suggested diff was corrected in three
places where it was wrong or overstated. Split into seven commits, one per
concern.

## What changed

**`index.py`** — the hard `import pysqlite3` meant the script would not start
on any machine without that package, even where the stdlib SQLite already has
FTS5. It now prefers pysqlite3 and falls back, probes FTS5 up front, and skips
episodes with no `_id` (which were silently inserting unaddressable NULL-id
rows on every run).

**Pipeline** — `verbose: true` in pods.yaml could never take effect; failed
downloads still went to the transcriber; and `findAudioLink` / `getMp3Info`
disagreed about what counts as audio, so a feed exposing
`<atom:link rel="enclosure">` with no `type` looped forever on "has no mp3
link". Empty transcriptions are now logged instead of dropped silently, and
`.env` resolution falls back to `./.env` so `installDist` and cron jobs work.

**Web** — user input went verbatim into `episodes_fts MATCH ?`, so `c++` or an
unbalanced quote returned a 500. Tag/collection filters used `LIKE '%value%'`,
so `art` matched `smart` and a supplied `%` matched everything. Filter values
were interpolated raw into search URLs, so a podcast titled `Tom & Jerry`
dropped filters on pagination. Feed HTML was rendered unescaped on both pages.

**CI** — `index.py` had no tests and no CI presence; it is now byte-compiled
and smoke-tested against a two-episode fixture generated in the workflow.

## Notes for review

- **New dependency**: `owasp-java-html-sanitizer` in the `web` module — the
  only new third-party code here.
- **The `indexer` CI job has never run on a real runner.** The step was
  validated by extracting it from the YAML and executing it locally, but this
  push is its first actual CI run.
- **The review's `writable_schema` fix did not work** and was replaced. Python's
  `sqlite3` ignores that pragma (it reads back as `0`) even though the `sqlite3`
  CLI honours it, so the FTS-drop recovery path failed exactly when needed —
  after already dropping the shadow tables and leaving a dangling schema entry.
  It now reports the problem and points at the fix.
- **Spaces are encoded as `%20`, not the `+` the review used.** Whether `+`
  decodes to a space in a *query string* is server-dependent, and podcast titles
  contain spaces constantly, so `+` risked reintroducing the bug being fixed.
- **The XSS was wider than the review reported.** It dismissed the search
  snippet as whisper-filtered transcript text, but the FTS table also indexes
  `episode_title` and `podcast_title`, both straight from the feed. Snippets now
  use `char(1)`/`char(2)` sentinels so the whole string can be escaped before
  highlights become markup.
- The review also claimed a typed-link-without-`rel` feed would pay the whisper
  cost and write nothing. It would not — `findAudioLink` runs at the top of the
  loop and skips those before any download. The predicate divergence was still
  real and is fixed.

## Verification

- 210 tests, 0 failures (was 179 at the reviewed commit).
- Every one of the seven commits builds and tests green on its own, checked in a
  scratch worktree, so `git bisect` stays usable.
- `safeFtsQuery` fuzzed over 237 FTS-metacharacter inputs: none still throw, and
  none degrade to returning the whole corpus.
- XSS verified against a running server with a hostile feed rather than only in
  unit tests — script tag, `onerror` image and `javascript:` link all gone from
  both pages, safe link preserved with `rel="nofollow"`.
- `index.py` run end to end on a synthetic data directory: fresh index, re-index
  over an existing DB, missing-`_id` handling, and an FTS query against the
  result. WAL confirmed still set after the new preflight DDL.

## Deliberately not done

`EpisodeRepository` still serialises on one connection, `Transcriber` still
hardcodes `language=en`, and `APP_VERSION` still duplicates the Gradle version.
These are design decisions or features rather than fixes.