### PR TITLE
Emit word timestamps, and stop inheriting the server's VAD flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ You will need the corresponding .mlmodelc file for your model, for example:
 curl -L -o ggml-large-v3-turbo-encoder.mlmodelc.zip https://huggingface.co/ggerganov/whisper.cpp/blob/main/ggml-large-v3-turbo-encoder.mlmodelc.zip
 ```
 
-It is highly recommended to also download a [VAD model](https://github.com/ggml-org/whisper.cpp?ref=shadowfinder.com#voice-activity-detection-vad). 
+A [VAD model](https://github.com/ggml-org/whisper.cpp?ref=shadowfinder.com#voice-activity-detection-vad) is **not** used by this pipeline and launching with `--vad` has no effect on it: the pipeline sends `vad=false` with every request, and whisper.cpp lets a request override the launch flags.
+
+That is deliberate. With VAD on, whisper.cpp keeps token timestamps in VAD-compressed time while remapping segment timestamps to real time, so the word timestamps in `words.jsonl.gz` would drift further out of step the longer the episode runs.
+
+
 
 ```bash
 whisper-server \
-  -m models/ggml-large-v3.bin \
-  --vad -vm models/ggml-silero-v5.1.2.bin
+  -m models/ggml-large-v3.bin
 ```
 
 #### Model: large-v3, not large-v3-turbo

--- a/pipeline/src/main/kotlin/com/rsstowhisper/Utils.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/Utils.kt
@@ -40,7 +40,39 @@ fun createPath(
     parentPath: Path,
     directoryName: String,
 ): Path {
-    val pathToCreate = parentPath.resolve(escapeFilename(directoryName))
+    val escaped = escapeFilename(directoryName)
+    val existing = findCaseInsensitive(parentPath, escaped)
+    if (existing != null) return existing
+    val pathToCreate = parentPath.resolve(escaped)
     Files.createDirectories(pathToCreate)
     return pathToCreate
+}
+
+/**
+ * `escapeFilename` preserves case, so re-capitalising a podcast's name in
+ * `pods.yaml` used to produce a SECOND directory for the same show. It
+ * happened: one feed shipped as both `HBR-Ideacast` (635 episodes) and
+ * `HBR-IdeaCast` (34). Downstream, train/test splits group on the first path
+ * component, so one show sat on both sides of the split boundary and leaked
+ * its hosts, jingles and recurring sponsors across it.
+ *
+ * Reusing the existing directory rather than case-folding the stored name:
+ * 17,750 directories exist, and renaming them is a migration in its own right.
+ * The defect is that a second directory can appear, not that the first has
+ * capitals.
+ */
+private fun findCaseInsensitive(
+    parentPath: Path,
+    name: String,
+): Path? {
+    if (!Files.isDirectory(parentPath)) return null
+    val match =
+        parentPath.toFile()
+            .listFiles()
+            ?.firstOrNull { it.isDirectory && it.name.equals(name, ignoreCase = true) }
+            ?: return null
+    if (match.name != name) {
+        logger.info("Reusing existing directory ${match.name} for $name (differs only by case)")
+    }
+    return match.toPath()
 }

--- a/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
@@ -72,7 +72,25 @@ open class Transcriber(
                     audioPath.toFile().asRequestBody("audio/mpeg".toMediaType()),
                 )
                 .addFormDataPart("language", "en")
-                .addFormDataPart("response_format", "vtt")
+                // verbose_json rather than vtt: per-word start/end are gated on
+                // token_timestamps, which is already on below, so the decode
+                // ALREADY computes these times and VTT discards them. A cue is
+                // the finest a span boundary can be placed, and 13.4% of the
+                // labelled advertisement airtime downstream currently sits in a
+                // cue too long to resolve. Word times take that to ~0.2s.
+                .addFormDataPart("response_format", "verbose_json")
+                // Explicit, and off. server.cpp:833 overrides only the fields a
+                // request actually sends, so omitting this silently inherits
+                // whatever the server was launched with -- which is how the
+                // corpus ended up with no record of its own VAD state.
+                //
+                // It has to be off: with VAD on, token timestamps stay in
+                // VAD-compressed time while segment timestamps are remapped to
+                // real time. Measured on one episode, the two drift apart from
+                // -1.79s at the start to -6.51s by the end, the gap being the
+                // silence VAD removed. Every word time would be early by a
+                // growing, episode-dependent, invisible amount.
+                .addFormDataPart("vad", "false")
                 // whisper.cpp only applies max_len when token_timestamps is on:
                 // the wrap call is nested inside `if (params.token_timestamps)`
                 // in whisper_full. Sending max_len alone is silently ignored.

--- a/pipeline/src/main/kotlin/com/rsstowhisper/external/WhisperTranscription.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/external/WhisperTranscription.kt
@@ -1,0 +1,116 @@
+package com.rsstowhisper.external
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.BufferedWriter
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.GZIPOutputStream
+
+/**
+ * One word, with the times whisper.cpp already computed for it.
+ *
+ * @param segment index of the cue this word came from, so the sidecar can be
+ *   joined back to the WebVTT without re-aligning the two.
+ * @param probability the decoder's own confidence. A run of low values is a
+ *   far better hallucination signal than anything derivable from the text.
+ */
+data class Word(
+    val text: String,
+    val start: Double,
+    val end: Double,
+    val probability: Double,
+    val segment: Int,
+)
+
+/**
+ * A parsed `verbose_json` response.
+ *
+ * The server can return WebVTT directly, and did until now. It is derived here
+ * instead because the two artifacts must describe the same decode: whisper is
+ * not deterministic across runs, so asking for both formats would mean two
+ * decodes whose cues and words could disagree in ways nothing downstream could
+ * detect. One request, one parse, two files written from it.
+ */
+data class WhisperTranscription(
+    val vtt: String,
+    val words: List<Word>,
+) {
+    val isEmpty: Boolean get() = vtt.isBlank() || vtt.trim() == VTT_HEADER
+
+    /** Newline-delimited JSON, gzipped. ~274 KB per episode before compression. */
+    fun writeWords(path: Path) {
+        val mapper = ObjectMapper()
+        Files.newOutputStream(path).use { raw ->
+            GZIPOutputStream(raw).use { gz ->
+                BufferedWriter(OutputStreamWriter(gz, StandardCharsets.UTF_8)).use { out ->
+                    words.forEach { w ->
+                        val node = mapper.createObjectNode()
+                        node.put("w", w.text)
+                        node.put("s", w.start)
+                        node.put("e", w.end)
+                        node.put("p", w.probability)
+                        node.put("seg", w.segment)
+                        out.write(mapper.writeValueAsString(node))
+                        out.newLine()
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val VTT_HEADER = "WEBVTT"
+        const val WORDS_FILENAME = "words.jsonl.gz"
+
+        private val mapper = ObjectMapper()
+
+        fun parse(json: String): WhisperTranscription {
+            val root = mapper.readTree(json)
+            val segments = root.path("segments")
+            if (!segments.isArray) return WhisperTranscription("$VTT_HEADER\n\n", emptyList())
+
+            val vtt = StringBuilder(VTT_HEADER).append("\n\n")
+            val words = mutableListOf<Word>()
+            segments.forEachIndexed { index, segment ->
+                val start = segment.path("start").asDouble()
+                val end = segment.path("end").asDouble()
+                vtt.append(timestamp(start)).append(" --> ").append(timestamp(end)).append('\n')
+                vtt.append(segment.path("text").asText()).append("\n\n")
+                segment.path("words").forEach { word ->
+                    words += word.toWord(index) ?: return@forEach
+                }
+            }
+            return WhisperTranscription(vtt.toString(), words)
+        }
+
+        /**
+         * Absent when the server was asked for timestamps it did not produce.
+         * Dropping the word is right: a word with no time cannot place a
+         * boundary, and a zero would place one at the start of the episode.
+         */
+        private fun JsonNode.toWord(segment: Int): Word? {
+            if (!has("start") || !has("end")) return null
+            return Word(
+                text = path("word").asText(),
+                start = path("start").asDouble(),
+                end = path("end").asDouble(),
+                probability = path("probability").asDouble(),
+                segment = segment,
+            )
+        }
+
+        /** `HH:MM:SS.mmm`, the WebVTT the server itself emits. */
+        internal fun timestamp(seconds: Double): String {
+            val safe = if (seconds.isFinite() && seconds > 0) seconds else 0.0
+            val millisTotal = Math.round(safe * 1000.0)
+            val hours = millisTotal / 3_600_000
+            val minutes = millisTotal % 3_600_000 / 60_000
+            val secs = millisTotal % 60_000 / 1000
+            val millis = millisTotal % 1000
+            return "%02d:%02d:%02d.%03d".format(hours, minutes, secs, millis)
+        }
+    }
+}

--- a/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
@@ -10,7 +10,9 @@ import com.rometools.rome.feed.synd.SyndFeed
 import com.rsstowhisper.AppConfig
 import com.rsstowhisper.PodcastConfig
 import com.rsstowhisper.createPath
+import com.rsstowhisper.escapeFilename
 import com.rsstowhisper.external.Transcriber
+import com.rsstowhisper.external.WhisperTranscription
 import com.rsstowhisper.feed.FeedService
 import com.rsstowhisper.timeToSeconds
 import okhttp3.OkHttpClient
@@ -120,8 +122,8 @@ class PodcastPipeline(
                     logger.warn("Could not download audio for $title. Skipping")
                     continue
                 }
-                val vtt = transcribeEpisode(mp3Info, episodeDirPath)
-                writeEpisodeJson(feed, entry, mp3Info, episodeDirPath, podcast.collections, vtt)
+                val transcription = WhisperTranscription.parse(transcribeEpisode(mp3Info, episodeDirPath))
+                writeEpisodeJson(feed, entry, mp3Info, episodeDirPath, podcast.collections, transcription)
             } catch (e: Exception) {
                 logger.error("Couldn't process episode entry: ${entry.title}")
                 logger.error(e.message, e)
@@ -135,20 +137,43 @@ class PodcastPipeline(
         mp3Info: Mp3Info,
         episodeDirPath: Path,
         collections: List<String>,
-        vtt: String,
+        transcription: WhisperTranscription,
     ) {
         val jsonPath = episodeDirPath.resolve("transcript.json")
         if (Files.exists(jsonPath)) return
-        if (vtt.isBlank()) {
+        if (transcription.isEmpty) {
             logger.warn("Transcription for ${entry.title} came back empty; not writing transcript.json")
             return
         }
 
         val episodeDict =
-            buildEpisodeDict(feed, entry, vtt, mp3Info.localFilePath, collections)
+            buildEpisodeDict(feed, entry, transcription.vtt, mp3Info.localFilePath, collections)
 
         if (episodeDict != null) {
+            // Words FIRST. transcript.json existing is what marks an episode
+            // done, both here and for anything reading the tree, so writing it
+            // last means a crash in between leaves the episode to be redone
+            // rather than leaving it permanently without its sidecar.
+            writeWords(transcription, episodeDirPath, entry)
             Files.writeString(jsonPath, jsonMapper.writeValueAsString(episodeDict))
+        }
+    }
+
+    private fun writeWords(
+        transcription: WhisperTranscription,
+        episodeDirPath: Path,
+        entry: SyndEntry,
+    ) {
+        if (transcription.words.isEmpty()) {
+            logger.warn("No word timestamps for ${entry.title}; is token_timestamps still set?")
+            return
+        }
+        try {
+            transcription.writeWords(episodeDirPath.resolve(WhisperTranscription.WORDS_FILENAME))
+        } catch (e: Exception) {
+            // Not fatal. The transcript is the artifact the pipeline exists to
+            // produce; the sidecar is an enrichment and can be rebuilt.
+            logger.error("Could not write word timestamps for ${entry.title}", e)
         }
     }
 
@@ -191,7 +216,22 @@ class PodcastPipeline(
             return "$date-${episodeId(entry)}"
         }
 
-        fun getEpisodeDirName(entry: SyndEntry): String = "${episodeStablePrefix(entry)}-${entry.title ?: "unknown"}"
+        /**
+         * A directory name with no `-<hex8>-` component cannot be resolved back
+         * to its audio: 97 episodes once stored one, and the keys pointed at
+         * nothing until a repair pass derived them from disk. Nothing about the
+         * construction below can produce that today, which is exactly why it is
+         * worth asserting -- a silent recurrence costs a re-ingest to find.
+         */
+        internal val EPISODE_DIR_PREFIX = Regex("^\\d{4}-\\d{2}-\\d{2}-[0-9a-f]{8}-")
+
+        fun getEpisodeDirName(entry: SyndEntry): String {
+            val name = "${episodeStablePrefix(entry)}-${entry.title ?: "unknown"}"
+            require(EPISODE_DIR_PREFIX.containsMatchIn(escapeFilename(name))) {
+                "Episode directory name is missing its date-id prefix: $name"
+            }
+            return name
+        }
 
         fun findExistingEpisodeDir(
             podPath: Path,

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
@@ -59,6 +59,7 @@ class TranscriberTest {
         assertTrue(partNames.any { it.contains("name=\"file\"") })
         assertTrue(partNames.any { it.contains("name=\"language\"") })
         assertTrue(partNames.any { it.contains("name=\"response_format\"") })
+        assertTrue(partNames.any { it.contains("name=\"vad\"") })
     }
 
     /**

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/WhisperServerIntegrationTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/WhisperServerIntegrationTest.kt
@@ -1,0 +1,100 @@
+package com.rsstowhisper.external
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Round-trips one real episode through a running whisper.cpp server.
+ *
+ * Opt-in: needs a server and an audio file, so CI never runs it. The unit
+ * tests cover the parse against a fixture; this covers the one thing a fixture
+ * cannot, which is whether the WebVTT rendered here is the WebVTT the server
+ * itself would have returned for the same audio.
+ *
+ *   WHISPER_IT_AUDIO=/path/to/audio.mp3 \
+ *   WHISPER_IT_SERVER=http://localhost:8080 \
+ *     ./gradlew :pipeline:test --tests '*WhisperServerIntegrationTest*'
+ */
+@EnabledIfEnvironmentVariable(named = "WHISPER_IT_AUDIO", matches = ".+")
+class WhisperServerIntegrationTest {
+    private val server: String = System.getenv("WHISPER_IT_SERVER") ?: "http://localhost:8080"
+    private val audio: Path = Path.of(System.getenv("WHISPER_IT_AUDIO"))
+
+    private val client =
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(90, TimeUnit.MINUTES)
+            .writeTimeout(30, TimeUnit.MINUTES)
+            .build()
+
+    /** The pipeline's own request with response_format swapped back to vtt. */
+    private fun serverVtt(): String {
+        val body =
+            MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("file", audio.fileName.toString(), audio.toFile().asRequestBody("audio/mpeg".toMediaType()))
+                .addFormDataPart("language", "en")
+                .addFormDataPart("response_format", "vtt")
+                .addFormDataPart("vad", "false")
+                .addFormDataPart("token_timestamps", "true")
+                .addFormDataPart("max_len", Transcriber.DEFAULT_MAX_LEN.toString())
+                .addFormDataPart("split_on_word", "true")
+                .addFormDataPart("prompt", Transcriber.DEFAULT_INITIAL_PROMPT)
+                .addFormDataPart("carry_initial_prompt", "true")
+                .build()
+        return client.newCall(Request.Builder().url("$server/inference").post(body).build())
+            .execute()
+            .use { it.body!!.string() }
+    }
+
+    @Test
+    fun `rendered vtt matches what the server returns for the same audio`() {
+        val parsed = WhisperTranscription.parse(Transcriber(server, client).transcribe(audio))
+        val reference = serverVtt()
+
+        fun cues(vtt: String) = vtt.lines().map { it.trim() }.filter { it.contains("-->") }
+
+        val ours = cues(parsed.vtt)
+        val theirs = cues(reference)
+        println("rendered ${ours.size} cues, server ${theirs.size}, ${parsed.words.size} words")
+        assertEquals(theirs, ours, "cue timing lines differ from the server's own VTT")
+        assertEquals(reference.trim(), parsed.vtt.trim(), "rendered VTT differs from the server's")
+    }
+
+    @Test
+    fun `word times sit inside their own cue`() {
+        val parsed = WhisperTranscription.parse(Transcriber(server, client).transcribe(audio))
+        assertTrue(parsed.words.isNotEmpty(), "no word timestamps came back")
+
+        val segments =
+            parsed.vtt.lines().filter { it.contains("-->") }.map { line ->
+                val (a, b) = line.split("-->").map { seconds(it.trim()) }
+                a to b
+            }
+        // A word may touch its cue's edges but must not sit outside them. This is
+        // what VAD breaks: token times stay in compressed time while segment
+        // times are remapped, so the two drift apart across the episode.
+        val strays =
+            parsed.words.filter { w ->
+                val (start, end) = segments[w.segment]
+                w.start < start - 0.05 || w.end > end + 0.05
+            }
+        println("${strays.size} of ${parsed.words.size} words outside their cue")
+        strays.take(3).forEach { println("  ${it.text} ${it.start}-${it.end} vs cue ${segments[it.segment]}") }
+        assertTrue(strays.size < parsed.words.size / 100, "words drifting outside their cues -- is VAD on?")
+    }
+
+    private fun seconds(ts: String): Double {
+        val (h, m, s) = ts.split(":")
+        return h.toInt() * 3600 + m.toInt() * 60 + s.toDouble()
+    }
+}

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/WhisperTranscriptionTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/WhisperTranscriptionTest.kt
@@ -1,0 +1,108 @@
+package com.rsstowhisper.external
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.GZIPInputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WhisperTranscriptionTest {
+    private val response =
+        """
+        {
+          "task": "transcribe",
+          "duration": 20.5,
+          "segments": [
+            {
+              "id": 0, "start": 1.79, "end": 10.49,
+              "text": " From APM, this is a show.",
+              "words": [
+                {"word": " From", "start": 1.79, "end": 2.04, "probability": 0.91},
+                {"word": " APM,", "start": 2.04, "end": 2.51, "probability": 0.72}
+              ]
+            },
+            {
+              "id": 1, "start": 10.96, "end": 13.61,
+              "text": " Here's the host.",
+              "words": [
+                {"word": " Here's", "start": 10.96, "end": 11.4, "probability": 0.99}
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+
+    @Test
+    fun `renders the WebVTT the server would have returned`() {
+        val vtt = WhisperTranscription.parse(response).vtt
+        assertEquals(
+            "WEBVTT\n\n" +
+                "00:00:01.790 --> 00:00:10.490\n From APM, this is a show.\n\n" +
+                "00:00:10.960 --> 00:00:13.610\n Here's the host.\n\n",
+            vtt,
+        )
+    }
+
+    @Test
+    fun `timestamps carry hours`() {
+        assertEquals("01:02:03.400", WhisperTranscription.timestamp(3723.4))
+        assertEquals("00:00:00.000", WhisperTranscription.timestamp(0.0))
+    }
+
+    @Test
+    fun `a negative or non-finite time clamps rather than formatting garbage`() {
+        assertEquals("00:00:00.000", WhisperTranscription.timestamp(-1.0))
+        assertEquals("00:00:00.000", WhisperTranscription.timestamp(Double.NaN))
+    }
+
+    @Test
+    fun `words carry their segment index so the sidecar can be joined to the cues`() {
+        val words = WhisperTranscription.parse(response).words
+        assertEquals(3, words.size)
+        assertEquals(listOf(0, 0, 1), words.map { it.segment })
+        assertEquals(" APM,", words[1].text)
+        assertEquals(2.04, words[1].start)
+        assertEquals(0.72, words[1].probability)
+    }
+
+    @Test
+    fun `a word with no timestamps is dropped rather than placed at zero`() {
+        val json =
+            """
+            {"segments":[{"id":0,"start":0.0,"end":1.0,"text":" Hi.",
+             "words":[{"word":" Hi.","probability":0.5}]}]}
+            """.trimIndent()
+        assertTrue(WhisperTranscription.parse(json).words.isEmpty())
+    }
+
+    @Test
+    fun `a response with no segments is empty rather than throwing`() {
+        val parsed = WhisperTranscription.parse("""{"task":"transcribe"}""")
+        assertTrue(parsed.isEmpty)
+        assertTrue(parsed.words.isEmpty())
+    }
+
+    @Test
+    fun `a parsed response with segments is not empty`() {
+        assertFalse(WhisperTranscription.parse(response).isEmpty)
+    }
+
+    @Test
+    fun `writeWords emits gzipped newline-delimited json`(
+        @TempDir tmp: Path,
+    ) {
+        val out = tmp.resolve(WhisperTranscription.WORDS_FILENAME)
+        WhisperTranscription.parse(response).writeWords(out)
+
+        val lines =
+            GZIPInputStream(Files.newInputStream(out)).bufferedReader().readLines()
+        assertEquals(3, lines.size)
+        assertTrue(lines[0].contains("\"w\":\" From\""))
+        assertTrue(lines[0].contains("\"s\":1.79"))
+        assertTrue(lines[0].contains("\"seg\":0"))
+        assertTrue(lines[2].contains("\"seg\":1"))
+    }
+}

--- a/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineRunTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineRunTest.kt
@@ -20,7 +20,15 @@ import kotlin.test.assertTrue
 
 private const val FAKE_SERVER_URL = "http://localhost:9000"
 
-private val MINIMAL_VTT = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n Hello world.\n"
+// The transcriber now returns verbose_json and the pipeline renders the WebVTT
+// from it, so a stub has to speak the same language the server does.
+private fun whisperJson(vararg cues: Triple<Double, Double, String>): String =
+    cues.joinToString(",", prefix = """{"task":"transcribe","segments":[""", postfix = "]}") { (start, end, text) ->
+        """{"id":0,"start":$start,"end":$end,"text":" $text",""" +
+            """"words":[{"word":" $text","start":$start,"end":$end,"probability":0.9}]}"""
+    }
+
+private val MINIMAL_VTT = whisperJson(Triple(0.0, 1.0, "Hello world."))
 
 class PodcastPipelineRunTest {
     private open class FakeFeedService(private val feeds: Map<String, SyndFeed?>) : FeedService() {
@@ -410,9 +418,10 @@ class PodcastPipelineRunTest {
         @TempDir tempDir: Path,
     ) {
         val vtt =
-            "WEBVTT\n\n" +
-                "00:00:00.000 --> 00:00:01.500\n First sentence.\n\n" +
-                "00:00:01.500 --> 00:00:03.000\n Second sentence.\n"
+            whisperJson(
+                Triple(0.0, 1.5, "First sentence."),
+                Triple(1.5, 3.0, "Second sentence."),
+            )
         val feed = makeFeed(makeEntry("Episode"))
         val (pipeline, _, _) =
             buildPipeline(


### PR DESCRIPTION
## What

`response_format` goes from `vtt` to `verbose_json`, the WebVTT is rendered from that parse, and the per-word times it carries are written alongside as `words.jsonl.gz`.

## Why it's free

Per-word `start`/`end` are gated on `token_timestamps`, which this pipeline has always sent (`server.cpp:1129`). **The decode already computes these times and rendering to WebVTT discards them.** No extra GPU, no model change, no retuning.

## Why it's worth doing

A span boundary can be no finer than the cue that holds it. Measured downstream across 698 labelled advertisement spans:

| | seconds |
|---|---:|
| median cue holding a boundary | 2.42 |
| p90 | 7.18 |
| p99 | 29.98 |
| **ad airtime that can't be resolved to ad or content** | **13.4%** |

Word times take that to roughly 0.2s. The value is in the ordinary 5-to-10 second tail (61% of the error), not the exact-30s window artefact (17%).

## VAD is now sent explicitly, and off

`Transcriber` never sent `vad`, and `server.cpp:833` overrides only the fields a request actually sends — so it silently inherited whatever the server was launched with. That's why the existing corpus has no record of its own VAD state.

It has to be off. With VAD on, whisper.cpp keeps token timestamps in VAD-compressed time while remapping segment timestamps to real time:

| | offset, first word vs its own segment |
|---|---|
| VAD on | −1.79s at the start, drifting to **−6.51s** by the end |
| VAD off | +0.00s to +0.20s, mean **+0.07s** |

Same episode, same model, same fields. The gap is the silence VAD removed — on a six-minute episode. Every word time would be early by a growing, episode-dependent, invisible amount.

The README's `--vad` launch recommendation is updated accordingly.

## Ordering and failure handling

- **One request, one parse, two files.** Whisper isn't deterministic across runs, so asking for both formats would mean two decodes whose cues and words could disagree undetectably.
- **`words.jsonl.gz` is written before `transcript.json`**, because the latter existing is what marks an episode done. A crash in between leaves the episode to be redone rather than permanently without a sidecar.
- **A sidecar failure is logged, not fatal.** The transcript is the artifact this pipeline exists to produce.

## Two path guards

Both defects already cost a repair pass downstream and would recur silently.

- `createPath` reuses a show directory differing only by case. One feed shipped as both `HBR-Ideacast` (635 episodes) and `HBR-IdeaCast` (34) after a name was recapitalised in `pods.yaml`; downstream splits group on the first path component, so one show sat on both sides of a train/test boundary. Reusing rather than case-folding — 17,750 directories exist and renaming them is its own migration.
- `getEpisodeDirName` asserts its `date-id` prefix. 97 episodes once stored a path with no `-<hex8>-` component and resolved to nothing on the audio volume.

## Not changed

`max_len`, `split_on_word`, `token_timestamps`, the prompt and `carry_initial_prompt` are untouched, and no `beam_size` is added — the corpus was decoded greedy and moving an unmeasured variable during a regeneration means never knowing which change did what.

## Testing

`ktlintCheck`, `test` and a clean `build` all pass. Unit coverage for VTT rendering, hour-carrying and clamped timestamps, segment indices on words, words missing timestamps being dropped rather than placed at zero, empty responses, and the gzipped JSONL output.

**Verified end to end against a running server** — 354s episode, `large-v3-turbo`, launched with no `--vad`:

```
rendered 74 cues, server 74, byte-identical VTT
1462 words, 0 outside their own cue
```

The first is the renderer: the WebVTT built here is exactly what the server would have returned for the same audio, so nothing downstream sees a different transcript than it would have before. The second is the VAD guard — with VAD on, words drift outside their cues by a growing margin, and zero strays is that not happening.

That test is opt-in (`WHISPER_IT_AUDIO`), so CI skips it.

## Running the server

Nothing in the pipeline manages the server process; it only POSTs to `PIPELINE_WHISPER_SERVER_URL`. After this change the launch line loses its VAD flags:

```bash
whisper-server -m /path/to/models/ggml-large-v3.bin --port 8080
```

`--vad` would now be overridden per request anyway, but it reads as though it were in effect, so it should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
