### PR TITLE
Configure the pipeline by argument, with .env as a fallback layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,18 @@ Three-stage pipeline for podcast transcription and full-text search:
 ./gradlew :pipeline:run
 ```
 
-All configuration comes from `pipeline/.env` — copy `pipeline/.env.example` and fill in:
+Configuration comes from `pipeline/.env` — copy `pipeline/.env.example` and fill in:
 - `PIPELINE_CONFIG_PATH` — path to your `pods.yaml`
 - `PIPELINE_DATA_DIRECTORY` — where audio and transcripts are stored
 - `PIPELINE_WHISPER_SERVER_URL` — URL of the whisper HTTP server
 - `PIPELINE_VERBOSE` — set to `true` to enable debug logging
+
+Each of those has a command-line equivalent that takes precedence (`--config`, `--data-dir`,
+`--whisper-url`, `--verbose`/`--no-verbose`), which is how two instances run side by side:
+
+```bash
+./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-b.yaml --whisper-url http://localhost:8082
+```
 
 Configure `pods.yaml` with:
 - `podcasts` — list of RSS feeds with `name`, `url`, and `collections` tags

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,11 @@ Three-stage pipeline for podcast transcription and full-text search:
 ### Pipeline (transcription)
 
 ```bash
-./gradlew :pipeline:run
+./transcribe
 ```
+
+`./transcribe` is a wrapper that runs `:pipeline:installDist` and execs the launcher,
+passing arguments through. `./gradlew :pipeline:run` still works for a single instance.
 
 Configuration comes from `pipeline/.env` — copy `pipeline/.env.example` and fill in:
 - `PIPELINE_CONFIG_PATH` — path to your `pods.yaml`
@@ -34,7 +37,7 @@ Each of those has a command-line equivalent that takes precedence (`--config`, `
 `--whisper-url`, `--verbose`/`--no-verbose`), which is how two instances run side by side:
 
 ```bash
-./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-b.yaml --whisper-url http://localhost:8082
+./transcribe --config ~/pods-b.yaml --whisper-url http://localhost:8082
 ```
 
 Configure `pods.yaml` with:

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Acceleration is determined by how the whisper.cpp `server` binary was compiled:
 
 ## Transcribing
 
-All pipeline configuration comes from `pipeline/.env` — there are no command-line arguments (see [Pipeline configuration](#pipeline-configuration) below).
+With `pipeline/.env` filled in (see [Pipeline configuration](#pipeline-configuration) below), no arguments are needed:
 
 ```bash
 ./gradlew :pipeline:run
@@ -210,6 +210,35 @@ Or build and run the distribution:
 ./gradlew :pipeline:installDist
 ./pipeline/build/install/pipeline/bin/pipeline
 ```
+
+Every `.env` setting also has a flag, which takes precedence over it — run
+`pipeline --help` for the list.
+
+### Running two instances at once
+
+Give each instance its own `pods.yaml` and its own whisper.cpp server. Use the installed
+distribution rather than `./gradlew :pipeline:run` twice: two concurrent Gradle
+invocations in one checkout serialise on the project lock.
+
+```bash
+./gradlew :pipeline:installDist
+```
+
+Then, in one terminal:
+
+```bash
+./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-a.yaml --whisper-url http://localhost:8081
+```
+
+and in another:
+
+```bash
+./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-b.yaml --whisper-url http://localhost:8082
+```
+
+Both can share one data directory, but nothing coordinates them: list a show in only one
+of the two files. If both walk the same feed they will download the same episode to the
+same `audio.mp3.part` staging file, and whichever finishes first deletes the other's.
 
 ## Indexing
 
@@ -278,7 +307,26 @@ than `true` counts as `false`, so `PIPELINE_VERBOSE=false` will override `verbos
 
 The `.env` file is resolved relative to the working directory: `pipeline/.env` is tried
 first (running from the repo root), then `./.env` (running from inside `pipeline/`, or
-next to an installed distribution).
+next to an installed distribution). A missing `.env` is fine as long as the arguments
+below supply the three required values.
+
+### Arguments
+
+| Flag | Overrides |
+| --- | --- |
+| `--config <path>` | `PIPELINE_CONFIG_PATH` |
+| `--data-dir <path>` | `PIPELINE_DATA_DIRECTORY` |
+| `--whisper-url <url>` | `PIPELINE_WHISPER_SERVER_URL` |
+| `--verbose` / `--no-verbose` | `PIPELINE_VERBOSE` |
+
+Precedence is argument, then `.env`, then `pods.yaml`. A flag that is not passed falls
+through, so `--whisper-url` alone leaves everything else coming from `.env`.
+
+Under Gradle the flags go through `--args`:
+
+```bash
+./gradlew :pipeline:run --args="--config ~/pods-a.yaml --whisper-url http://localhost:8081"
+```
 
 ### `pods.yaml`
 

--- a/README.md
+++ b/README.md
@@ -322,11 +322,16 @@ below supply the three required values.
 Precedence is argument, then `.env`, then `pods.yaml`. A flag that is not passed falls
 through, so `--whisper-url` alone leaves everything else coming from `.env`.
 
-Under Gradle the flags go through `--args`:
+Under Gradle the flags go through `--args`. Gradle splits that string itself rather than
+handing it to a shell, so write `$HOME` or an absolute path — a `~` inside the quotes
+arrives at the pipeline literally and the config file is not found:
 
 ```bash
-./gradlew :pipeline:run --args="--config ~/pods-a.yaml --whisper-url http://localhost:8081"
+./gradlew :pipeline:run --args="--config $HOME/pods-a.yaml --whisper-url http://localhost:8081"
 ```
+
+A bad flag exits `2`, unusable configuration exits `1`, and both messages go to stderr, so
+a wrapper script can tell a failed launch from a run that found nothing to do.
 
 ### `pods.yaml`
 

--- a/README.md
+++ b/README.md
@@ -201,40 +201,43 @@ Acceleration is determined by how the whisper.cpp `server` binary was compiled:
 With `pipeline/.env` filled in (see [Pipeline configuration](#pipeline-configuration) below), no arguments are needed:
 
 ```bash
-./gradlew :pipeline:run
+./transcribe
 ```
 
-Or build and run the distribution:
+`./transcribe` builds the distribution and runs it, so a source change can never leave you
+running a stale binary. It passes its arguments straight through and exits with the
+pipeline's own status, and it resolves `.env` and relative paths against your current
+directory — it is the long form below with the path memorised for you:
 
 ```bash
 ./gradlew :pipeline:installDist
 ./pipeline/build/install/pipeline/bin/pipeline
 ```
 
+`./gradlew :pipeline:run` also works, with the caveats under
+[Arguments](#arguments) below.
+
 Every `.env` setting also has a flag, which takes precedence over it — run
-`pipeline --help` for the list.
+`./transcribe --help` for the list.
 
 ### Running two instances at once
 
-Give each instance its own `pods.yaml` and its own whisper.cpp server. Use the installed
-distribution rather than `./gradlew :pipeline:run` twice: two concurrent Gradle
-invocations in one checkout serialise on the project lock.
+Give each instance its own `pods.yaml` and its own whisper.cpp server. In one terminal:
 
 ```bash
-./gradlew :pipeline:installDist
-```
-
-Then, in one terminal:
-
-```bash
-./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-a.yaml --whisper-url http://localhost:8081
+./transcribe --config ~/pods-a.yaml --whisper-url http://localhost:8081
 ```
 
 and in another:
 
 ```bash
-./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-b.yaml --whisper-url http://localhost:8082
+./transcribe --config ~/pods-b.yaml --whisper-url http://localhost:8082
 ```
+
+Don't use `./gradlew :pipeline:run` for this — two concurrent Gradle invocations in one
+checkout serialise on the project lock. `./transcribe` takes that lock only for its build
+and has released it by the time the pipeline starts, so a second launch waits a second at
+most.
 
 Both can share one data directory, but nothing coordinates them: list a show in only one
 of the two files. If both walk the same feed they will download the same episode to the

--- a/README.md
+++ b/README.md
@@ -330,8 +330,10 @@ arrives at the pipeline literally and the config file is not found:
 ./gradlew :pipeline:run --args="--config $HOME/pods-a.yaml --whisper-url http://localhost:8081"
 ```
 
-A bad flag exits `2`, unusable configuration exits `1`, and both messages go to stderr, so
-a wrapper script can tell a failed launch from a run that found nothing to do.
+A bad flag exits `2` with its message on stderr. Unusable configuration exits `1` — that
+covers a missing `--config` as well as a data directory that is missing or not writable. A
+run that found nothing new to transcribe exits `0`, so a wrapper script can tell a failed
+launch from a quiet one.
 
 ### `pods.yaml`
 

--- a/pipeline/.env.example
+++ b/pipeline/.env.example
@@ -4,3 +4,6 @@ PIPELINE_CONFIG_PATH=/path/to/pods.yaml
 # Optional; when set it overrides `verbose` in pods.yaml. Leave commented out
 # to let pods.yaml decide.
 #PIPELINE_VERBOSE=true
+
+# Every setting above has a command-line equivalent that overrides it:
+# --config, --data-dir, --whisper-url, --verbose/--no-verbose. Run with --help.

--- a/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/AppConfig.kt
@@ -22,27 +22,35 @@ data class AppConfig(
                 .registerModule(KotlinModule.Builder().build())
                 .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
 
-        fun load(): AppConfig = load(loadDotEnv())
+        internal fun load(args: Args): AppConfig = load(args, loadDotEnv())
 
-        internal fun load(env: Map<String, String>): AppConfig {
+        internal fun load(env: Map<String, String>): AppConfig = load(Args(), env)
+
+        internal fun load(
+            args: Args,
+            env: Map<String, String>,
+        ): AppConfig {
             val configPath =
-                env["PIPELINE_CONFIG_PATH"]
-                    ?: error("PIPELINE_CONFIG_PATH must be set in .env")
+                args.configPath
+                    ?: env["PIPELINE_CONFIG_PATH"]
+                    ?: error("PIPELINE_CONFIG_PATH must be set in .env, or passed as --config")
             val dataDirectory =
-                env["PIPELINE_DATA_DIRECTORY"]
-                    ?: error("PIPELINE_DATA_DIRECTORY must be set in .env")
+                args.dataDirectory
+                    ?: env["PIPELINE_DATA_DIRECTORY"]
+                    ?: error("PIPELINE_DATA_DIRECTORY must be set in .env, or passed as --data-dir")
             val whisperServerUrl =
-                env["PIPELINE_WHISPER_SERVER_URL"]
-                    ?: error("PIPELINE_WHISPER_SERVER_URL must be set in .env")
+                args.whisperServerUrl
+                    ?: env["PIPELINE_WHISPER_SERVER_URL"]
+                    ?: error("PIPELINE_WHISPER_SERVER_URL must be set in .env, or passed as --whisper-url")
             // Blank means "not set" -- an empty PIPELINE_VERBOSE= line must fall
             // through to pods.yaml rather than forcing it off via toBoolean().
-            val verbose = env["PIPELINE_VERBOSE"]?.takeIf { it.isNotBlank() }?.toBoolean()
+            val envVerbose = env["PIPELINE_VERBOSE"]?.takeIf { it.isNotBlank() }?.toBoolean()
 
             val raw: AppConfig = mapper.readValue(File(configPath))
             return raw.copy(
                 dataDirectory = dataDirectory,
                 whisperServerUrl = whisperServerUrl,
-                verbose = verbose ?: raw.verbose,
+                verbose = args.verbose ?: envVerbose ?: raw.verbose,
             )
         }
 

--- a/pipeline/src/main/kotlin/com/rsstowhisper/Args.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/Args.kt
@@ -1,0 +1,59 @@
+package com.rsstowhisper
+
+internal val USAGE =
+    """
+    Usage: pipeline [options]
+
+    Options:
+      --config <path>        Path to pods.yaml                  (PIPELINE_CONFIG_PATH)
+      --data-dir <path>      Where audio and transcripts go     (PIPELINE_DATA_DIRECTORY)
+      --whisper-url <url>    Base URL of the whisper.cpp server (PIPELINE_WHISPER_SERVER_URL)
+      --verbose              Enable debug logging               (PIPELINE_VERBOSE)
+      --no-verbose           Force debug logging off
+      -h, --help             Show this message
+
+    Options override .env, which overrides pods.yaml. Give a second instance its
+    own --config and --whisper-url to run two feeds against two whisper servers.
+    """.trimIndent()
+
+/** Null means "not given", so each field can fall through to .env and then pods.yaml. */
+internal data class Args(
+    val configPath: String? = null,
+    val dataDirectory: String? = null,
+    val whisperServerUrl: String? = null,
+    val verbose: Boolean? = null,
+    val help: Boolean = false,
+)
+
+internal fun parseArgs(argv: Array<String>): Args {
+    var args = Args()
+    var i = 0
+    while (i < argv.size) {
+        val flag = argv[i]
+        args =
+            when (flag) {
+                "--config" -> args.copy(configPath = valueFor(flag, argv, ++i))
+                "--data-dir" -> args.copy(dataDirectory = valueFor(flag, argv, ++i))
+                "--whisper-url" -> args.copy(whisperServerUrl = valueFor(flag, argv, ++i))
+                "--verbose" -> args.copy(verbose = true)
+                "--no-verbose" -> args.copy(verbose = false)
+                "-h", "--help" -> args.copy(help = true)
+                else ->
+                    if (flag.startsWith("-")) {
+                        error("Unknown option: $flag (try --help)")
+                    } else {
+                        error("Unexpected argument: $flag (try --help)")
+                    }
+            }
+        i++
+    }
+    return args
+}
+
+private fun valueFor(
+    flag: String,
+    argv: Array<String>,
+    index: Int,
+): String =
+    argv.getOrNull(index)?.takeUnless { it.startsWith("-") }
+        ?: error("$flag needs a value (try --help)")

--- a/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
@@ -5,10 +5,23 @@ import ch.qos.logback.classic.LoggerContext
 import com.rsstowhisper.pipeline.PodcastPipeline
 import org.slf4j.LoggerFactory
 
-fun main() {
+fun main(argv: Array<String>) {
+    val args: Args =
+        try {
+            parseArgs(argv)
+        } catch (e: IllegalStateException) {
+            println(e.message)
+            return
+        }
+
+    if (args.help) {
+        println(USAGE)
+        return
+    }
+
     val config: AppConfig =
         try {
-            AppConfig.load()
+            AppConfig.load(args)
         } catch (e: Exception) {
             println("Cannot load configuration: ${e.message}")
             return

--- a/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
@@ -34,5 +34,7 @@ fun main(argv: Array<String>) {
     }
 
     val pipeline = PodcastPipeline(config)
-    pipeline.run()
+    if (!pipeline.run()) {
+        exitProcess(1)
+    }
 }

--- a/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/Main.kt
@@ -4,14 +4,15 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.LoggerContext
 import com.rsstowhisper.pipeline.PodcastPipeline
 import org.slf4j.LoggerFactory
+import kotlin.system.exitProcess
 
 fun main(argv: Array<String>) {
     val args: Args =
         try {
             parseArgs(argv)
         } catch (e: IllegalStateException) {
-            println(e.message)
-            return
+            System.err.println(e.message)
+            exitProcess(2)
         }
 
     if (args.help) {
@@ -23,8 +24,8 @@ fun main(argv: Array<String>) {
         try {
             AppConfig.load(args)
         } catch (e: Exception) {
-            println("Cannot load configuration: ${e.message}")
-            return
+            System.err.println("Cannot load configuration: ${e.message}")
+            exitProcess(1)
         }
 
     if (config.verbose) {

--- a/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/pipeline/PodcastPipeline.kt
@@ -42,17 +42,19 @@ class PodcastPipeline(
             configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
         }
 
-    fun run() {
+    /** False when the run never started, so a supervisor sees a failed launch rather than a quiet no-op. */
+    fun run(): Boolean {
         val dataDir = config.dataDirectory
 
         if (!Files.isWritable(Path.of(dataDir))) {
             logger.error("The data_dir is missing, or not writable. Cannot continue")
-            return
+            return false
         }
 
         for (podcast in config.podcasts) {
             processPodcast(podcast, dataDir)
         }
+        return true
     }
 
     private fun processPodcast(

--- a/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/AppConfigTest.kt
@@ -186,6 +186,80 @@ class AppConfigTest {
     }
 
     @Test
+    fun `load lets args override env for every value`(
+        @TempDir tmp: Path,
+    ) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("verbose: false\n")
+        val argsYaml = tmp.resolve("args.yaml").toFile()
+        argsYaml.writeText("verbose: false\nskip_after_consecutive: 7\n")
+
+        val config =
+            AppConfig.load(
+                Args(
+                    configPath = argsYaml.absolutePath,
+                    dataDirectory = "/args/data",
+                    whisperServerUrl = "http://args-whisper",
+                    verbose = true,
+                ),
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/env/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://env-whisper",
+                    "PIPELINE_VERBOSE" to "false",
+                ),
+            )
+
+        assertEquals(7, config.skipAfterConsecutive)
+        assertEquals("/args/data", config.dataDirectory)
+        assertEquals("http://args-whisper", config.whisperServerUrl)
+        assertEquals(true, config.verbose)
+    }
+
+    @Test
+    fun `load works from args alone with no env at all`(
+        @TempDir tmp: Path,
+    ) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("podcasts: []\n")
+
+        val config =
+            AppConfig.load(
+                Args(
+                    configPath = yaml.absolutePath,
+                    dataDirectory = "/args/data",
+                    whisperServerUrl = "http://args-whisper",
+                ),
+                emptyMap(),
+            )
+
+        assertEquals("/args/data", config.dataDirectory)
+        assertEquals("http://args-whisper", config.whisperServerUrl)
+        assertEquals(false, config.verbose)
+    }
+
+    @Test
+    fun `load lets --no-verbose override a true env var`(
+        @TempDir tmp: Path,
+    ) {
+        val yaml = tmp.resolve("pods.yaml").toFile()
+        yaml.writeText("verbose: true\n")
+
+        val config =
+            AppConfig.load(
+                Args(verbose = false),
+                mapOf(
+                    "PIPELINE_CONFIG_PATH" to yaml.absolutePath,
+                    "PIPELINE_DATA_DIRECTORY" to "/data",
+                    "PIPELINE_WHISPER_SERVER_URL" to "http://whisper",
+                    "PIPELINE_VERBOSE" to "true",
+                ),
+            )
+
+        assertEquals(false, config.verbose)
+    }
+
+    @Test
     fun `load errors when PIPELINE_CONFIG_PATH is missing`() {
         val ex =
             assertFailsWith<IllegalStateException> {
@@ -196,7 +270,7 @@ class AppConfigTest {
                     ),
                 )
             }
-        assertEquals("PIPELINE_CONFIG_PATH must be set in .env", ex.message)
+        assertEquals("PIPELINE_CONFIG_PATH must be set in .env, or passed as --config", ex.message)
     }
 
     @Test
@@ -215,7 +289,7 @@ class AppConfigTest {
                     ),
                 )
             }
-        assertEquals("PIPELINE_DATA_DIRECTORY must be set in .env", ex.message)
+        assertEquals("PIPELINE_DATA_DIRECTORY must be set in .env, or passed as --data-dir", ex.message)
     }
 
     @Test
@@ -234,6 +308,6 @@ class AppConfigTest {
                     ),
                 )
             }
-        assertEquals("PIPELINE_WHISPER_SERVER_URL must be set in .env", ex.message)
+        assertEquals("PIPELINE_WHISPER_SERVER_URL must be set in .env, or passed as --whisper-url", ex.message)
     }
 }

--- a/pipeline/src/test/kotlin/com/rsstowhisper/ArgsTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/ArgsTest.kt
@@ -1,0 +1,75 @@
+package com.rsstowhisper
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ArgsTest {
+    @Test
+    fun `parseArgs returns everything unset for empty argv`() {
+        assertEquals(Args(), parseArgs(emptyArray()))
+    }
+
+    @Test
+    fun `parseArgs reads every value flag`() {
+        val args =
+            parseArgs(
+                arrayOf(
+                    "--config",
+                    "/tmp/pods.yaml",
+                    "--data-dir",
+                    "/tmp/data",
+                    "--whisper-url",
+                    "http://localhost:8081",
+                ),
+            )
+
+        assertEquals("/tmp/pods.yaml", args.configPath)
+        assertEquals("/tmp/data", args.dataDirectory)
+        assertEquals("http://localhost:8081", args.whisperServerUrl)
+    }
+
+    @Test
+    fun `parseArgs maps verbose flags to true false and null`() {
+        assertEquals(true, parseArgs(arrayOf("--verbose")).verbose)
+        assertEquals(false, parseArgs(arrayOf("--no-verbose")).verbose)
+        assertNull(parseArgs(arrayOf("--config", "/tmp/pods.yaml")).verbose)
+    }
+
+    @Test
+    fun `parseArgs recognises both help spellings`() {
+        assertTrue(parseArgs(arrayOf("--help")).help)
+        assertTrue(parseArgs(arrayOf("-h")).help)
+    }
+
+    @Test
+    fun `parseArgs takes the last value when a flag is repeated`() {
+        assertEquals("/second", parseArgs(arrayOf("--config", "/first", "--config", "/second")).configPath)
+    }
+
+    @Test
+    fun `parseArgs rejects an unknown option`() {
+        val ex = assertFailsWith<IllegalStateException> { parseArgs(arrayOf("--nope")) }
+        assertEquals("Unknown option: --nope (try --help)", ex.message)
+    }
+
+    @Test
+    fun `parseArgs rejects a bare positional`() {
+        val ex = assertFailsWith<IllegalStateException> { parseArgs(arrayOf("pods.yaml")) }
+        assertEquals("Unexpected argument: pods.yaml (try --help)", ex.message)
+    }
+
+    @Test
+    fun `parseArgs rejects a value flag at the end of argv`() {
+        val ex = assertFailsWith<IllegalStateException> { parseArgs(arrayOf("--whisper-url")) }
+        assertEquals("--whisper-url needs a value (try --help)", ex.message)
+    }
+
+    @Test
+    fun `parseArgs rejects a value flag followed by another flag`() {
+        val ex = assertFailsWith<IllegalStateException> { parseArgs(arrayOf("--config", "--verbose")) }
+        assertEquals("--config needs a value (try --help)", ex.message)
+    }
+}

--- a/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineRunTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/pipeline/PodcastPipelineRunTest.kt
@@ -125,6 +125,30 @@ class PodcastPipelineRunTest {
     }
 
     @Test
+    fun `run returns false when the data dir is missing`(
+        @TempDir tempDir: Path,
+    ) {
+        val (pipeline, _, feedSvc) =
+            buildPipeline(
+                tempDir.resolve("not-created"),
+                listOf(PodcastConfig(name = "Show", url = "https://feed")),
+                makeFeed(makeEntry("My Episode")),
+            )
+
+        assertFalse(pipeline.run())
+        assertTrue(feedSvc.requestedUrls.isEmpty())
+    }
+
+    @Test
+    fun `run returns true when there is nothing to do`(
+        @TempDir tempDir: Path,
+    ) {
+        val (pipeline, _, _) = buildPipeline(tempDir, emptyList(), makeFeed())
+
+        assertTrue(pipeline.run())
+    }
+
+    @Test
     fun `run transcribes episode and writes json output`(
         @TempDir tempDir: Path,
     ) {

--- a/transcribe
+++ b/transcribe
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Build first, so a source change can never leave you running a stale binary.
+set -e
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+"$root/gradlew" --quiet --project-dir "$root" :pipeline:installDist
+
+# exec from the caller's directory: .env discovery and relative --config paths
+# are resolved against it, exactly as for the launcher itself.
+exec "$root/pipeline/build/install/pipeline/bin/pipeline" "$@"


### PR DESCRIPTION
## Why

Running two pipeline instances at once — two `pods.yaml` files against two whisper.cpp servers — was impossible. `fun main()` took no arguments, and `AppConfig.load()` resolves `.env` relative to the working directory (`pipeline/.env`, then `./.env`), so two processes started from the same checkout necessarily read the same config. That is not something a wrapper can work around; the values have to arrive per-invocation.

## What

Command-line arguments become the primary configuration surface, with `.env` demoted to a default layer underneath. Precedence is **argument → `.env` → `pods.yaml`**.

| Flag | Overrides |
| --- | --- |
| `--config <path>` | `PIPELINE_CONFIG_PATH` |
| `--data-dir <path>` | `PIPELINE_DATA_DIRECTORY` |
| `--whisper-url <url>` | `PIPELINE_WHISPER_SERVER_URL` |
| `--verbose` / `--no-verbose` | `PIPELINE_VERBOSE` |

Passing nothing behaves exactly as it did before. A missing `.env` is now a supported state rather than a guaranteed failure, so an instance can be specified entirely on the command line.

Failures are loud, which the old `fun main()` was not: a usage error exits `2`, unusable configuration exits `1`, and both messages go to stderr instead of stdout. Previously every failure printed to stdout and exited `0`, so a supervisor or `&&` chain around two instances read a typo'd flag as a successful run that transcribed nothing. `--help` still prints to stdout and exits `0`.

```bash
./gradlew :pipeline:installDist
./pipeline/build/install/pipeline/bin/pipeline --config ~/pods-a.yaml --whisper-url http://localhost:8081
```

## Notes on the shape

- **Hand-rolled parsing**, no new dependency — this would have been the repo's first CLI library, and the parser mirrors the existing hand-rolled `loadDotEnv`.
- **`verbose` is `Boolean?`** so "not passed" stays distinguishable from `--no-verbose`, for the same reason the env layer treats a blank `PIPELINE_VERBOSE=` as unset.
- **`AppConfig.load(env)` survives as a shim** over the new `load(args, env)`, so the existing config tests needed no structural change beyond the three reworded error messages.
- **`load(args: Args)` is `internal`**, not public — `Args` is internal, and Kotlin rejects the leak.
- **No build file change**: `MainKt` is still a valid entry point with the `Array<String>` signature.

## Shared data directory

Two instances can share one `PIPELINE_DATA_DIRECTORY`, but nothing coordinates them. If a show appears in both YAML files, both processes download the same episode to the same `audio.mp3.part`, and whichever finishes first deletes the other's in-flight file via the `finally` cleanup in `FeedService`. Deliberately documented rather than fixed — the intent is two shows in parallel, not one show split across instances.

## Verification

`./gradlew ktlintCheck test` passes. Beyond the unit tests, exercised against the installed distribution:

- Exit codes and streams, measured on the installed binary: `--nope` → `2` on stderr, `--whisper-url` with no value → `2` on stderr, an unreadable `--config` → `1` on stderr, `--help` → `0` on stdout, a valid args-only run → `0`.
- The exit code survives the Gradle wrapper: `:pipeline:run` with a bad `--config` fails the build rather than reporting success.
- Two instances launched concurrently with different `--config`/`--data-dir`/`--whisper-url` both ran and completed independently.
- `--data-dir` pointed at a missing directory produces `The data_dir is missing, or not writable` — proof the argument reaches `PodcastPipeline`, not just `AppConfig`.
- With a `.env` in the working directory and no arguments, the old path is unchanged; adding `--data-dir` overrides that `.env` value.

All end-to-end runs used throwaway `pods.yaml` files with empty podcast lists — no real feeds were touched.

New tests cover `parseArgs` (each flag, the three verbose states, both help spellings, repeated flags, and the three error paths) and `AppConfig` precedence (args beat env for every value, args-only with an empty env map, `--no-verbose` over a `true` env var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
