### PR TITLE
Decode with beam search; the server's greedy default was never chosen

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,34 @@ seconds. A cue that long cannot carry a usable timestamp.
 
 `split_on_word` cuts at word boundaries rather than mid-token.
 
-### No `beam_size` — the decode is greedy
+### `beam_size=5` — not the server's greedy default
 
 whisper-server defaults to greedy and whisper-cli to `beam_size=5`; both run
-`strategy = beam_size > 1 ? BEAM_SEARCH : GREEDY`. Greedy is deliberate here.
-Beam is worth reaching for when repairing an already-collapsed decode, but it
-has not been shown to help a healthy one, and changing it during a bulk run
-means never knowing which change did what.
+`strategy = beam_size > 1 ? BEAM_SEARCH : GREEDY`. Adopting the server without
+sending this field silently put the pipeline on greedy.
+
+Greedy's characteristic failure is repetition: it locks onto a phrase and emits
+it for minutes. It hit 0.7%–5.0% of episodes per show across the first eleven
+regenerated shows, and a repair pass running beam has fixed **57 of 57** of
+them, most on the first attempt.
+
+A paired trial on one show — same audio, same model, same fields, only
+`beam_size` moved — found beam equal or better on healthy material too:
+
+| | greedy | beam |
+|---|---:|---:|
+| median punctuation/word | 0.1546 | 0.1611 |
+| sub-threshold loops cleared | — | 5 of 5 |
+| clamped / unpunctuated episodes | 0 | 0 |
+
+and it rescued a shredded episode outright, 0.74 s/cue to 2.42 with punctuation
+0.109 → 0.208.
+
+The costs are real but small: roughly 30% more decode time, and about 12% fewer
+cues. Coarser cues used to matter because the cue was the floor on boundary
+precision; with per-word times in `words.jsonl.gz` it no longer is.
+
+Set `beamSize = 1` for greedy.
 
 ## Platform acceleration
 

--- a/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
+++ b/pipeline/src/main/kotlin/com/rsstowhisper/external/Transcriber.kt
@@ -54,6 +54,34 @@ open class Transcriber(
      * word count within 5% of the original.
      */
     private val initialPrompt: String = DEFAULT_INITIAL_PROMPT,
+    /**
+     * Beam width. whisper.cpp runs
+     * `strategy = beam_size > 1 ? BEAM_SEARCH : GREEDY`, and the server
+     * defaults to greedy while whisper-cli defaults to 5 -- so adopting the
+     * server silently put this pipeline on greedy decoding.
+     *
+     * Greedy's characteristic failure here is repetition: it locks onto a
+     * phrase and emits it for minutes. Measured across the first eleven
+     * regenerated shows it hits 0.7%-5.0% of episodes per show, and the repair
+     * pass that cleans them up runs beam. That pass has now fixed **57 of 57**
+     * such episodes, most on its first attempt.
+     *
+     * A paired trial on one show -- same audio, same model, same fields, only
+     * this value moved -- found beam equal or better on healthy material:
+     *
+     *   median punctuation/word   0.1546 -> 0.1611
+     *   sub-threshold loops       5 of 5 cleared
+     *   a shredded episode        0.74 s/cue -> 2.42, punctuation 0.109 -> 0.208
+     *   clamped / unpunctuated    0 either way
+     *
+     * The costs are real but small: roughly 30% more decode time, and about
+     * 12% fewer cues. Coarser cues used to matter because the cue was the
+     * floor on how precisely a span boundary could be placed; with per-word
+     * times in `words.jsonl.gz` it no longer is.
+     *
+     * Set to 1 for greedy.
+     */
+    private val beamSize: Int = DEFAULT_BEAM_SIZE,
 ) {
     private val logger = LoggerFactory.getLogger(Transcriber::class.java)
 
@@ -98,6 +126,7 @@ open class Transcriber(
                 .addFormDataPart("max_len", maxLen.toString())
                 // Cut on word boundaries rather than mid-token.
                 .addFormDataPart("split_on_word", "true")
+                .addFormDataPart("beam_size", beamSize.toString())
 
         if (initialPrompt.isNotBlank()) {
             bodyBuilder.addFormDataPart("prompt", initialPrompt)
@@ -128,6 +157,9 @@ open class Transcriber(
 
     companion object {
         const val DEFAULT_MAX_LEN = 200
+
+        /** See [beamSize]. 1 is greedy, which is what the server defaults to. */
+        const val DEFAULT_BEAM_SIZE = 5
 
         /** See [initialPrompt]. Ordinary punctuated prose, nothing domain-specific. */
         const val DEFAULT_INITIAL_PROMPT =

--- a/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
+++ b/pipeline/src/test/kotlin/com/rsstowhisper/external/TranscriberTest.kt
@@ -33,6 +33,35 @@ class TranscriberTest {
 
     private fun mp3File(tmp: Path): Path = tmp.resolve("audio.mp3").also { Files.writeString(it, "fake-mp3-data") }
 
+    private fun partValue(
+        request: okhttp3.Request,
+        name: String,
+    ): String {
+        val body = request.body as okhttp3.MultipartBody
+        val part = body.parts.single { it.headers!!["Content-Disposition"]!!.contains("name=\"$name\"") }
+        val sink = okio.Buffer()
+        part.body.writeTo(sink)
+        return sink.readUtf8()
+    }
+
+    @Test
+    fun `transcribe sends the configured beam size, and 1 means greedy`(
+        @TempDir tmp: Path,
+    ) {
+        val requests = mutableListOf<okhttp3.Request>()
+        Transcriber("http://whisper-server", clientReturning("{}", captureRequests = requests))
+            .transcribe(mp3File(tmp))
+        assertEquals(
+            Transcriber.DEFAULT_BEAM_SIZE.toString(),
+            partValue(requests.single(), "beam_size"),
+        )
+
+        val greedy = mutableListOf<okhttp3.Request>()
+        Transcriber("http://whisper-server", beamSize = 1, httpClient = clientReturning("{}", captureRequests = greedy))
+            .transcribe(mp3File(tmp))
+        assertEquals("1", partValue(greedy.single(), "beam_size"))
+    }
+
     @Test
     fun `transcribe posts to the inference endpoint`(
         @TempDir tmp: Path,
@@ -60,6 +89,7 @@ class TranscriberTest {
         assertTrue(partNames.any { it.contains("name=\"language\"") })
         assertTrue(partNames.any { it.contains("name=\"response_format\"") })
         assertTrue(partNames.any { it.contains("name=\"vad\"") })
+        assertTrue(partNames.any { it.contains("name=\"beam_size\"") })
     }
 
     /**


### PR DESCRIPTION
## What

`Transcriber` now sends `beam_size` (default 5). It never did, so whisper-server's greedy default applied — `strategy = beam_size > 1 ? BEAM_SEARCH : GREEDY`. whisper-cli defaults to 5; adopting the server put this pipeline on greedy by accident rather than by decision.

## Why

Greedy's characteristic failure here is **repetition** — locking onto a phrase and emitting it for minutes. Across the first eleven regenerated shows it hits **0.7%–5.0% of episodes per show**, and the downstream repair pass that cleans them up runs beam. That pass has now fixed **57 of 57**, most on its first attempt.

The open question was whether beam damages healthy episodes. A paired trial on one show — same audio, same model, same fields, only `beam_size` moved, 55 episodes — says no:

| | greedy | beam |
|---|---:|---:|
| median punctuation/word | 0.1546 | **0.1611** |
| median seconds per cue | 3.6655 | 3.7068 |
| episodes shredded | 2 | 2 |
| episodes clamped / unpunctuated | 0 | 0 |
| episodes with inverted word times | 1 | 1 *(the same episode)* |

Beam also cleared **5 of 5 sub-threshold loops** greedy had left, and rescued a shredded episode outright: 0.74 s/cue → 2.42, punctuation 0.109 → 0.208.

An earlier attempt to answer this moved four variables at once — model, VAD, prompt and strategy — and settled nothing. This moved one.

## Costs

**~30% more decode time**, and **~12% fewer cues**. The second used to matter because the cue was the floor on how precisely a span boundary could be placed. With per-word times in `words.jsonl.gz` it no longer is — the floor is now ~0.19s regardless.

## Not a full endorsement yet

The trial excluded episodes a repair sweep had already rewritten with beam, which happened to be exactly the episodes that *had* loops — so it demonstrates "beam does not hurt healthy material" rather than "beam fixes loops". The loop evidence comes from the repair pass instead.

One more show is being decoded with this before committing the remaining ~28. Shows already regenerated stay greedy; the corpus will be mixed, which is tolerable because train/test splits are grouped by show, but it needs recording.

## Testing

`ktlintCheck`, `test` and a clean `build` pass. New coverage asserts the field is sent and that a configured value is carried through, including `beamSize = 1` for greedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)